### PR TITLE
Normal fitter: expose chi squared calculation directly

### DIFF
--- a/ionics_fits/normal.py
+++ b/ionics_fits/normal.py
@@ -106,7 +106,7 @@ class NormalFitter(Fitter):
         self,
         x: Array[("num_samples",), np.float64],
         y: Array[("num_samples", "num_y_channels"), np.float64],
-        sigma: Optional[Array[("num_samples", "num_y_channels"), np.float64]],
+        sigma: Array[("num_samples", "num_y_channels"), np.float64],
     ) -> float:
         """Returns the Chi-squared fit significance for the fit compared to a given
         dataset as a number between 0 and 1.
@@ -144,8 +144,7 @@ class NormalFitter(Fitter):
         """Returns an estimate of the goodness of fit as a number between 0 and 1 or
         `None` if `sigma` has not been supplied. See :meth chi_squared: for details.
         """
-        sigma = self.sigma
-        if sigma is None:
+        if self.sigma is None:
             return None
 
-        return self.chi_squared(self.x, self.y, sigma)
+        return self.chi_squared(self.x, self.y, self.sigma)

--- a/ionics_fits/normal.py
+++ b/ionics_fits/normal.py
@@ -144,7 +144,8 @@ class NormalFitter(Fitter):
         """Returns an estimate of the goodness of fit as a number between 0 and 1 or
         `None` if `sigma` has not been supplied. See :meth chi_squared: for details.
         """
-        if self.sigma is None:
+        sigma = self.sigma
+        if sigma is None:
             return None
 
-        return self.chi_squared(self.x, self.y, self.sigma)
+        return self.chi_squared(self.x, self.y, sigma)

--- a/ionics_fits/normal.py
+++ b/ionics_fits/normal.py
@@ -102,31 +102,49 @@ class NormalFitter(Fitter):
 
         return p, p_err
 
-    def _fit_significance(self) -> Optional[float]:
-        """Returns an estimate of the goodness of fit as a number between 0 and 1 or
-        `None` if `sigma` has not been supplied.
+    def chi_squared(
+        self,
+        x: Array[("num_samples",), np.float64],
+        y: Array[("num_samples", "num_y_channels"), np.float64],
+        sigma: Optional[Array[("num_samples", "num_y_channels"), np.float64]],
+    ) -> float:
+        """Returns the Chi-squared fit significance for the fit compared to a given
+        dataset as a number between 0 and 1.
 
-        This is the defined as the probability that fit residuals as large as the ones
+        The significance gives the probability that fit residuals as large as the ones
         we observe could have arisen through chance given our assumed statistics and
-        assuming that the fitted model perfectly represents the probability distribution
+        assuming that the fitted model perfectly represents the probability
+        distribution.
 
         A value of `1` indicates a perfect fit (all data points lie on the fitted curve)
-        a value close to 0 indicates significant deviations of the dataset from the
-        fitted model.
+        a value close to 0 indicates super-statistical deviations of the dataset from
+        the fitted model.
+        """
+        if sigma.shape != y.shape:
+            raise ValueError(
+                f"Mismatch between shapes of sigma ({sigma.shape}) and y ({y.shape})"
+            )
+
+        n = y.size - len(self.free_parameters)
+
+        if n < 1:
+            raise ValueError(
+                "Cannot calculate chi squared for fit with "
+                f"{len(self.free_parameters)} floated parameters and only "
+                f"{len(x)} data points."
+            )
+
+        y_fit = self.model.func(x, self.values)
+        chi_2 = np.sum(np.power((y - y_fit) / sigma, 2))
+        p = stats.chi2.sf(chi_2, n)
+
+        return p
+
+    def _fit_significance(self) -> Optional[float]:
+        """Returns an estimate of the goodness of fit as a number between 0 and 1 or
+        `None` if `sigma` has not been supplied. See :meth chi_squared: for details.
         """
         if self.sigma is None:
             return None
 
-        n = self.y.size - len(self.free_parameters)
-
-        if n < 1:
-            raise ValueError(
-                "Cannot calculate chi squared with "
-                f"{len(self.free_parameters)} fit parameters and only "
-                f"{len(self.x)} data points."
-            )
-
-        y_fit = self.evaluate()[1]
-        chi_2 = np.sum(np.power((self.y - y_fit) / self.sigma, 2))
-        p = stats.chi2.sf(chi_2, n)
-        return p
+        return self.chi_squared(self.x, self.y, self.sigma)

--- a/poetry.lock
+++ b/poetry.lock
@@ -199,14 +199,14 @@ pyflakes = ">=2.4.0,<2.5.0"
 
 [[package]]
 name = "fonttools"
-version = "4.39.3"
+version = "4.39.4"
 description = "Tools to manipulate font files"
 category = "dev"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "fonttools-4.39.3-py3-none-any.whl", hash = "sha256:64c0c05c337f826183637570ac5ab49ee220eec66cf50248e8df527edfa95aeb"},
-    {file = "fonttools-4.39.3.zip", hash = "sha256:9234b9f57b74e31b192c3fc32ef1a40750a8fbc1cd9837a7b7bfc4ca4a5c51d7"},
+    {file = "fonttools-4.39.4-py3-none-any.whl", hash = "sha256:106caf6167c4597556b31a8d9175a3fdc0356fdcd70ab19973c3b0d4c893c461"},
+    {file = "fonttools-4.39.4.zip", hash = "sha256:dba8d7cdb8e2bac1b3da28c5ed5960de09e59a2fe7e63bb73f5a59e57b0430d2"},
 ]
 
 [package.extras]
@@ -851,18 +851,18 @@ tests = ["check-manifest", "coverage", "defusedxml", "markdown2", "olefile", "pa
 
 [[package]]
 name = "platformdirs"
-version = "3.5.0"
+version = "3.5.1"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "platformdirs-3.5.0-py3-none-any.whl", hash = "sha256:47692bc24c1958e8b0f13dd727307cff1db103fca36399f457da8e05f222fdc4"},
-    {file = "platformdirs-3.5.0.tar.gz", hash = "sha256:7954a68d0ba23558d753f73437c55f89027cf8f5108c19844d4b82e5af396335"},
+    {file = "platformdirs-3.5.1-py3-none-any.whl", hash = "sha256:e2378146f1964972c03c085bb5662ae80b2b8c06226c54b2ff4aa9483e8a13a5"},
+    {file = "platformdirs-3.5.1.tar.gz", hash = "sha256:412dae91f52a6f84830f39a8078cecd0e866cb72294a5c66808e74d5e88d251f"},
 ]
 
 [package.extras]
-docs = ["furo (>=2023.3.27)", "proselint (>=0.13)", "sphinx (>=6.1.3)", "sphinx-autodoc-typehints (>=1.23,!=1.23.4)"]
+docs = ["furo (>=2023.3.27)", "proselint (>=0.13)", "sphinx (>=6.2.1)", "sphinx-autodoc-typehints (>=1.23,!=1.23.4)"]
 test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.3.1)", "pytest-cov (>=4)", "pytest-mock (>=3.10)"]
 
 [[package]]


### PR DESCRIPTION
This is useful, for example, if the user wants to calculate the chi-squared value for a subset of the data. 