### PR TITLE
Initial commit of model for squeezed motional state

### DIFF
--- a/ionics_fits/models/__init__.py
+++ b/ionics_fits/models/__init__.py
@@ -4,8 +4,10 @@ from .exponential import Exponential
 from .gaussian import Gaussian
 from .laser_rabi import (
     LaserFlopFreqCoherent,
+    LaserFlopFreqSqueezed,
     LaserFlopFreqThermal,
     LaserFlopTimeCoherent,
+    LaserFlopTimeSqueezed,
     LaserFlopTimeThermal,
 )
 from .lorentzian import Lorentzian

--- a/ionics_fits/models/laser_rabi.py
+++ b/ionics_fits/models/laser_rabi.py
@@ -48,9 +48,8 @@ def make_laser_flop(base_class, distribution_fun):
         The model requires that the internal part of the system starts out
         entirely in one of the ground or excited states, specified using
         :meth:`__init__`'s :param:`start_excited` parameter. It further assumes
-        that the motional part of the system starts out as a statistical mixture
-        of different Fock states, the occupation probabilities of which are
-        determined by means of the parameter `distribution_fun`.
+        that the motional part of the system starts out in a distribution
+        over different Fock states, described by the parameter `distribution_fun`.
 
         Independent variables:
             - t_pulse: duration of driving pulse including dead time. The duration of
@@ -186,9 +185,10 @@ def make_laser_flop(base_class, distribution_fun):
                 * (1 - np.exp(-t / tau) * np.cos(W * t))
             )
 
-            P_fock_i = self.distribution_fun(self.n_max, **kwargs)
+            # Occupation probabilities of Fock states
+            P_fock = self.distribution_fun(self.n_max, **kwargs)
             # Transition probability averaged over Fock state distribution
-            P_trans_mean = np.sum(P_fock_i * P_trans, axis=-1).squeeze()
+            P_trans_mean = np.sum(P_fock * P_trans, axis=-1).squeeze()
 
             P_e = 1 - P_trans_mean if self.start_excited else P_trans_mean
 

--- a/ionics_fits/models/quantum_phys.py
+++ b/ionics_fits/models/quantum_phys.py
@@ -65,7 +65,7 @@ def squeezed_state_probs(
     where a_dag and a denote the harmonic-oscillator creation and annihilation
     operators.
 
-    The occupation probabilites are truncated at the maximum Fock state |n_max>.
+    The occupation probabilities are truncated at the maximum Fock state |n_max>.
 
     :param zeta: Complex squeezing parameter
     """

--- a/ionics_fits/models/quantum_phys.py
+++ b/ionics_fits/models/quantum_phys.py
@@ -27,7 +27,14 @@ def coherent_state_probs(
     n_max: int, alpha: ModelParameter(lower_bound=0)
 ) -> Array[("num_fock_states",), np.float64]:
     """Returns an array of the Fock state occupation probabilities for a coherent
-    state described by :param alpha:, truncated at a maximum Fock state of |n_max>
+    state described by :param alpha:, truncated at a maximum Fock state of |n_max>.
+
+    A coherent state is defined as
+        |α> = exp(α a_dag - α* a) |0>,
+    where a_dag and a denote the harmonic-oscillator creation and annihilation
+    operators.
+
+    :param alpha: Complex displacement parameter
     """
     n = np.arange(n_max + 1, dtype=int)
     n_bar = np.power(np.abs(alpha), 2)
@@ -40,6 +47,47 @@ def coherent_state_probs(
         P_n[0] = 1
     else:
         P_n = np.exp(n * np.log(n_bar) - n_bar - special.gammaln(n + 1))
+    return P_n
+
+
+# pytype: enable=invalid-annotation
+
+
+# pytype: disable=invalid-annotation
+def squeezed_state_probs(
+    n_max: int, zeta: ModelParameter(lower_bound=0)
+) -> Array[("num_fock_states",), np.float64]:
+    """
+    Return occupation probabilities of Fock states for pure squeezed state.
+
+    A pure squeezed state is defined as
+        |ζ> = exp[1 / 2 *  (ζ* a^2 - ζ a_dag^2)] |0>,
+    where a_dag and a denote the harmonic-oscillator creation and annihilation
+    operators.
+
+    The occupation probabilites are truncated at the maximum Fock state |n_max>.
+
+    :param zeta: Complex squeezing parameter
+    """
+    n = np.arange(n_max + 1, dtype=int)
+
+    r = np.abs(zeta)
+    if r == 0:
+        P_n = np.zeros_like(n)
+        P_n[0] = 1
+    else:
+        P_n = (
+            np.power(np.tanh(r), 2 * n)
+            / np.cosh(r)
+            * np.exp(
+                special.gammaln(2 * n + 1)
+                - 2 * n * np.log(2)
+                - 2 * special.gammaln(n + 1)
+            )
+        )
+        # For a squeezed state, only even Fock states are occupied
+        P_n[1::2] = 0
+
     return P_n
 
 

--- a/test/test_laser_flop.py
+++ b/test/test_laser_flop.py
@@ -79,6 +79,13 @@ def test_laser_flop_freq(plot_failures: bool):
         flop_class=fits.models.LaserFlopFreqThermal,
         dist_params={"n_bar": [0.1, 0.1, 1]},
     )
+    _test_laser_flop_freq(
+        plot_failures=plot_failures,
+        P_readout_e=1.0,
+        sideband_index=+1,
+        flop_class=fits.models.LaserFlopFreqSqueezed,
+        dist_params={"zeta": 1.0},
+    )
 
 
 def _test_laser_flop_time(
@@ -152,4 +159,11 @@ def test_laser_flop_time(plot_failures: bool):
         sideband_index=+1,
         flop_class=fits.models.LaserFlopTimeThermal,
         dist_params={"n_bar": [0, 0.1, 1]},
+    )
+    _test_laser_flop_time(
+        plot_failures=plot_failures,
+        P_readout_e=1.0,
+        sideband_index=+1,
+        flop_class=fits.models.LaserFlopTimeSqueezed,
+        dist_params={"zeta": 1.0},
     )


### PR DESCRIPTION
This PR adds the ability to fit laser flops for squeezed motional states.

Additionally, it makes the following minor modifications:
-) When calculating transition probabilities in `LaserFlop`, the `np.tile` function is no longer used. Calling this was not necessary since the array containing occupation probabilities for Fock states (now called `P_fock_i`) is broadcast anyway to match the shape of `P_trans`. In fact, the numpy documentation explicitly recommends not to use the `tile` function for broadcasting:
![image](https://github.com/OxIonics/ionics_fits/assets/18437684/d231b408-df22-4502-81bc-db6bb16ba291)
-) I have expanded the docstring for `LaserFlop` a bit to reflect that, contrary to `RabiFlop`, this class assumes that the system has a motional degree of freedom.