### PR TITLE
Change ordering of array for y-axis data

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ print(f"Amplitude: dataset = {params['a']:.3f}, fit = {fit.values['a']:.3f}")
 print(f"Phase: dataset = {params['phi']:.3f}, fit = {fit.values['phi']:.3f}")
 
 plt.plot(x, y, label="data")
-plt.plot(*fit.evaluate(), '-.o', label="fit")
+plt.plot(*fit.evaluate(True), '-.o', label="fit")
 plt.grid()
 plt.legend()
 plt.show()

--- a/ionics_fits/common.py
+++ b/ionics_fits/common.py
@@ -733,20 +733,20 @@ class Fitter:
 
     def evaluate(
         self,
+        transpose_and_squeeze=False,
         x_fit: Optional[Array[("num_samples",), np.float64]] = None,
-        transpose_and_squeeze=True,
     ) -> Tuple[
         Array[("num_samples",), np.float64],
         Array[("num_y_channels", "num_samples"), np.float64],
     ]:
         """Evaluates the model function using the fitted parameter set.
 
-        :param x_fit: optional x-axis points to evaluate the model at. If `None` we use
-            the values stored as attribute `x` of the fitter.
         :param transpose_and_squeeze: if True, array `y_fit` is transposed
             and squeezed before being returned. This is intended to be used
             for plotting, since matplotlib requires different y-series to be
             stored as columns.
+        :param x_fit: optional x-axis points to evaluate the model at. If
+            `None`, we use the values stored as attribute `x` of the fitter.
 
         :returns: tuple of x-axis values used and corresponding y-axis values
             of the fitted model
@@ -760,4 +760,4 @@ class Fitter:
 
     def residuals(self) -> Array[("num_y_channels", "num_samples"), np.float64]:
         """Returns an array of fit residuals."""
-        return self.y - self.evaluate(transpose_and_squeeze=False)[1]
+        return self.y - self.evaluate()[1]

--- a/ionics_fits/common.py
+++ b/ionics_fits/common.py
@@ -484,7 +484,7 @@ class Fitter:
     results as attributes.
 
     Attributes:
-        x: 1D ndarray of shape (num_samples) containing x-axis values of valid points.
+        x: 1D ndarray of shape (num_samples,) containing x-axis values of valid points.
         y: 2D ndarray of shape (num_y_channels, num_samples) containing y-axis values
             of valid points.
         sigma: optional 2D ndarray of shape (num_y_channels, num_samples) containing
@@ -742,11 +742,14 @@ class Fitter:
         """Evaluates the model function using the fitted parameter set.
 
         :param x_fit: optional x-axis points to evaluate the model at. If `None` we use
-            the dataset values. If a scalar we generate an axis of linearly spaced
-            points between the minimum and maximum value of the x-axis dataset.
-            Otherwise it should be an array of x-axis data points to use.
+            the values stored as attribute `x` of the fitter.
+        :param transpose_and_squeeze: if True, array `y_fit` is transposed
+            and squeezed before being returned. This is intended to be used
+            for plotting, since matplotlib requires different y-series to be
+            stored as columns.
 
-        :returns: tuple of x-axis values used and model values for those points
+        :returns: tuple of x-axis values used and corresponding y-axis values
+            of the fitted model
         """
         x_fit = x_fit if x_fit is not None else self.x
         y_fit = self.model.func(x_fit, self.values)

--- a/ionics_fits/common.py
+++ b/ionics_fits/common.py
@@ -4,7 +4,7 @@ import copy
 import inspect
 import logging
 import numpy as np
-from typing import Callable, Dict, List, Optional, Tuple, TYPE_CHECKING, Union
+from typing import Callable, Dict, List, Optional, Tuple, TYPE_CHECKING
 from .utils import Array, ArrayLike
 
 
@@ -733,7 +733,7 @@ class Fitter:
 
     def evaluate(
         self,
-        x_fit: Optional[Union[Array[("num_samples",), np.float64], int]] = None,
+        x_fit: Optional[Array[("num_samples",), np.float64]] = None,
         transpose_and_squeeze=True,
     ) -> Tuple[
         Array[("num_samples",), np.float64],
@@ -749,17 +749,12 @@ class Fitter:
         :returns: tuple of x-axis values used and model values for those points
         """
         x_fit = x_fit if x_fit is not None else self.x
-
-        if np.isscalar(x_fit):
-            x_fit = np.linspace(np.min(self.x), np.max(self.x), x_fit)
-
         y_fit = self.model.func(x_fit, self.values)
 
         if transpose_and_squeeze:
-            return x_fit, y_fit.T.squeeze()  # type: ignore
-        else:
-            return x_fit, y_fit  # type: ignore
+            return x_fit, y_fit.T.squeeze()
+        return x_fit, y_fit
 
     def residuals(self) -> Array[("num_y_channels", "num_samples"), np.float64]:
         """Returns an array of fit residuals."""
-        return self.y - self.evaluate()[1]
+        return self.y - self.evaluate(transpose_and_squeeze=False)[1]

--- a/ionics_fits/models/containers.py
+++ b/ionics_fits/models/containers.py
@@ -77,7 +77,6 @@ class AggregateModel(Model):
         y: Array[("num_y_channels", "num_samples"), np.float64],
         model_parameters: Dict[str, ModelParameter],
     ):
-        y = np.atleast_2d(y)
         for idx, (model_name, model) in enumerate(self.models):
             params = {
                 param_name: model_parameters[f"{model_name}_{param_name}"]
@@ -92,8 +91,6 @@ class AggregateModel(Model):
         fitted_params: Dict[str, float],
         fit_uncertainties: Dict[str, float],
     ) -> Tuple[Dict[str, float], Dict[str, float]]:
-        y = np.atleast_2d(y)
-
         derived_params = {}
         derived_uncertainties = {}
 
@@ -216,8 +213,6 @@ class RepeatedModel(Model):
         y: Array[("num_y_channels", "num_samples"), np.float64],
         model_parameters: Dict[str, ModelParameter],
     ):
-        y = np.atleast_2d(y)
-
         dim = self.inner.get_num_y_channels()
 
         common_params = {param: model_parameters[param] for param in self.common_params}
@@ -228,9 +223,7 @@ class RepeatedModel(Model):
                 for param in self.independent_params
             }
             params.update(copy.deepcopy(common_params))
-            self.inner.estimate_parameters(
-                x, y[idx * dim : (idx + 1) * dim].squeeze(), params
-            )
+            self.inner.estimate_parameters(x, y[idx * dim : (idx + 1) * dim], params)
 
             for param in self.common_params:
                 common_heuristics[param].append(params[param].get_initial_value())
@@ -245,8 +238,6 @@ class RepeatedModel(Model):
         fitted_params: Dict[str, float],
         fit_uncertainties: Dict[str, float],
     ) -> Tuple[Dict[str, float], Dict[str, float]]:
-        y = np.atleast_2d(y)
-
         derived_params = {}
         derived_uncertainties = {}
 
@@ -271,7 +262,7 @@ class RepeatedModel(Model):
 
             derived = self.inner.calculate_derived_params(
                 x=x,
-                y=y[idx * dim : (idx + 1) * dim].squeeze(),
+                y=y[idx * dim : (idx + 1) * dim],
                 fitted_params=rep_params,
                 fit_uncertainties=rep_uncertainties,
             )

--- a/ionics_fits/models/exponential.py
+++ b/ionics_fits/models/exponential.py
@@ -23,6 +23,10 @@ class Exponential(Model):
       - x_1_e: x-axis value for 1/e decay including dead time (`x_1_e = x0 + tau`)
     """
 
+    def get_num_y_channels(self) -> int:
+        """Returns the number of y channels supported by the model"""
+        return 1
+
     # pytype: disable=invalid-annotation
     def _func(
         self,
@@ -63,6 +67,9 @@ class Exponential(Model):
         :param model_parameters: dictionary mapping model parameter names to their
             metadata, rescaled if allowed.
         """
+        # Ensure that y is a 1D array
+        y = np.squeeze(y)
+
         # Exponentials are generally pretty easy to fit so we keep the estimator simple
         model_parameters["x_dead"].heuristic = 0
         model_parameters["y0"].heuristic = y[0]

--- a/ionics_fits/models/gaussian.py
+++ b/ionics_fits/models/gaussian.py
@@ -28,6 +28,10 @@ class Gaussian(Model):
       - w0: full width at 1/e max height. For Gaussian beams this is the beam waist
     """
 
+    def get_num_y_channels(self) -> int:
+        """Returns the number of y channels supported by the model"""
+        return 1
+
     # pytype: disable=invalid-annotation
     def _func(
         self,
@@ -70,6 +74,9 @@ class Gaussian(Model):
         :param model_parameters: dictionary mapping model parameter names to their
             metadata, rescaled if allowed.
         """
+        # Ensure that y is a 1D array
+        y = np.squeeze(y)
+
         # Gaussian Fourier Transform:
         #   F[A * exp(-(x/w)^2)](k) = A * sqrt(pi) * w * exp(-(pi*k*w)^2)
         #

--- a/ionics_fits/models/lorentzian.py
+++ b/ionics_fits/models/lorentzian.py
@@ -25,6 +25,10 @@ class Lorentzian(Model):
         None
     """
 
+    def get_num_y_channels(self) -> int:
+        """Returns the number of y channels supported by the model"""
+        return 1
+
     # pytype: disable=invalid-annotation
     def _func(
         self,
@@ -62,6 +66,9 @@ class Lorentzian(Model):
         :param model_parameters: dictionary mapping model parameter names to their
             metadata.
         """
+        # Ensure that y is a 1D array
+        y = np.squeeze(y)
+
         omega, spectrum = get_spectrum(x, y, trim_dc=True)
         abs_spectrum = np.abs(spectrum)
 

--- a/ionics_fits/models/polynomial.py
+++ b/ionics_fits/models/polynomial.py
@@ -42,6 +42,10 @@ class Power(Model):
         None
     """
 
+    def get_num_y_channels(self) -> int:
+        """Returns the number of y channels supported by the model"""
+        return 1
+
     # pytype: disable=invalid-annotation
     def _func(
         self,
@@ -79,6 +83,9 @@ class Power(Model):
         :param model_parameters: dictionary mapping model parameter names to their
             metadata, rescaled if allowed.
         """
+        # Ensure that y is a 1D array
+        y = np.squeeze(y)
+
         unknowns = {
             param
             for param, param_data in model_parameters.items()
@@ -235,6 +242,10 @@ class Polynomial(Model):
         self.poly_degree = poly_degree
         super().__init__(parameters=_generate_poly_parameters(poly_degree))
 
+    def get_num_y_channels(self) -> int:
+        """Returns the number of y channels supported by the model"""
+        return 1
+
     def func(
         self, x: Array[("num_samples",), np.float64], params: Dict[str, float]
     ) -> Array[("num_samples",), np.float64]:
@@ -270,6 +281,9 @@ class Polynomial(Model):
         :param model_parameters: dictionary mapping model parameter names to their
             metadata, rescaled if allowed.
         """
+        # Ensure that y is a 1D array
+        y = np.squeeze(y)
+
         model_parameters["x0"].heuristic = 0.0
         x0 = model_parameters["x0"].get_initial_value()
 

--- a/ionics_fits/models/rabi.py
+++ b/ionics_fits/models/rabi.py
@@ -63,6 +63,10 @@ class RabiFlop(Model):
         super().__init__()
         self.start_excited = start_excited
 
+    def get_num_y_channels(self) -> int:
+        """Returns the number of y channels supported by the model"""
+        return 1
+
     # pytype: disable=invalid-annotation
     def _func(
         self,
@@ -175,6 +179,9 @@ class RabiFlopFreq(RabiFlop):
         y: Array[("num_samples",), np.float64],
         model_parameters: Dict[str, ModelParameter],
     ):
+        # Ensure that y is a 1D array
+        y = np.squeeze(y)
+
         model_parameters["t_dead"].heuristic = 0.0
         model_parameters["tau"].heuristic = np.inf
 
@@ -286,6 +293,9 @@ class RabiFlopTime(RabiFlop):
         y: Array[("num_samples",), np.float64],
         model_parameters: Dict[str, ModelParameter],
     ):
+        # Ensure that y is a 1D array
+        y = np.squeeze(y)
+
         model_parameters["t_dead"].heuristic = 0.0
         model_parameters["tau"].heuristic = np.inf
 

--- a/ionics_fits/models/rectangle.py
+++ b/ionics_fits/models/rectangle.py
@@ -31,6 +31,10 @@ class Rectangle(Model):
         self.thresh = thresh
         super().__init__()
 
+    def get_num_y_channels(self) -> int:
+        """Returns the number of y channels supported by the model"""
+        return 1
+
     # pytype: disable=invalid-annotation
     def _func(
         self,
@@ -65,6 +69,8 @@ class Rectangle(Model):
         :param model_parameters: dictionary mapping model parameter names to their
             metadata, rescaled if allowed.
         """
+        # Ensure that y is a 1D array
+        y = np.squeeze(y)
 
         unknowns = {
             param

--- a/ionics_fits/models/sinc.py
+++ b/ionics_fits/models/sinc.py
@@ -25,6 +25,10 @@ class Sinc(Model):
       None
     """
 
+    def get_num_y_channels(self) -> int:
+        """Returns the number of y channels supported by the model"""
+        return 1
+
     # pytype: disable=invalid-annotation
     def _func(
         self,
@@ -62,6 +66,9 @@ class Sinc(Model):
         :param model_parameters: dictionary mapping model parameter names to their
             metadata.
         """
+        # Ensure that y is a 1D array
+        y = np.squeeze(y)
+
         model_parameters["y0"].heuristic = np.mean([y[0], y[-1]])
         y0 = model_parameters["y0"].get_initial_value()
 
@@ -108,6 +115,10 @@ class Sinc2(Model):
       None
     """
 
+    def get_num_y_channels(self) -> int:
+        """Returns the number of y channels supported by the model"""
+        return 1
+
     # pytype: disable=invalid-annotation
     def _func(
         self,
@@ -146,6 +157,9 @@ class Sinc2(Model):
         :param model_parameters: dictionary mapping model parameter names to their
             metadata.
         """
+        # Ensure that y is a 1D array
+        y = np.squeeze(y)
+
         y0 = model_parameters["y0"].heuristic = np.mean([y[0], y[-1]])
 
         omega, spectrum = get_spectrum(x, y, trim_dc=True)

--- a/ionics_fits/models/sinusoid.py
+++ b/ionics_fits/models/sinusoid.py
@@ -40,6 +40,10 @@ class Sinusoid(Model):
     fixed at 0 and phi0 is floated.
     """
 
+    def get_num_y_channels(self) -> int:
+        """Returns the number of y channels supported by the model"""
+        return 1
+
     # pytype: disable=invalid-annotation
     def _func(
         self,

--- a/ionics_fits/models/sinusoid.py
+++ b/ionics_fits/models/sinusoid.py
@@ -93,6 +93,9 @@ class Sinusoid(Model):
         :param model_parameters: dictionary mapping model parameter names to their
             metadata, rescaled if allowed.
         """
+        # Ensure that y is a 1D array
+        y = np.squeeze(y)
+
         # We don't have good heuristics for these parameters
         model_parameters["y0"].heuristic = np.mean(y)
         model_parameters["tau"].heuristic = np.max(x)

--- a/ionics_fits/models/triangle.py
+++ b/ionics_fits/models/triangle.py
@@ -31,6 +31,10 @@ class Triangle(Model):
       - k_p: slope for x >= x0
     """
 
+    def get_num_y_channels(self) -> int:
+        """Returns the number of y channels supported by the model"""
+        return 1
+
     # pytype: disable=invalid-annotation
     def _func(
         self,
@@ -79,7 +83,10 @@ class Triangle(Model):
         :param model_parameters: dictionary mapping model parameter names to their
             metadata, rescaled if allowed.
         """
-        # Written to be handle the case of data which is only well-modelled by a
+        # Ensure that y is a 1D array
+        y = np.squeeze(y)
+
+        # Written to handle the case of data which is only well-modelled by a
         # triangle function near `x0` but saturates further away
         model_parameters["y_max"].heuristic = max(y)
         model_parameters["y_min"].heuristic = min(y)

--- a/ionics_fits/models/utils.py
+++ b/ionics_fits/models/utils.py
@@ -84,20 +84,16 @@ def get_spectrum(
 ]:
     """Returns the frequency spectrum (Fourier transform) of a dataset.
 
-    :param x: x-axis data
-    :param y: y-axis data. For models with multiple y-channels, this must be
-        an array of shape (num_samples,) or (1, num_samples) containing data
-        from a single channel only.
+    :param x: 1D ndarray of shape (num_samples,) containing x-axis data
+    :param y: 1D ndarray of shape (num_samples,) containing y-axis data
     :param density_units: if `False` we apply normalization for narrow-band signals. If
         `True` we normalize for continuous distributions.
     :param trim_dc: if `True` we do not return the DC component.
     """
-    if y.ndim != 1 and y.shape[0] != 1:
-        raise ValueError(
-            f"{y.shape[0]} y-channels were provided to a method which takes 1."
-        )
-    # Ensure that y is a 1D array
-    y = np.squeeze(y)
+    if x.ndim != 1:
+        raise ValueError("x-axis data must be a 1D array.")
+    if y.ndim != 1:
+        raise ValueError("y-axis data must be a 1D array.")
 
     dx = x.ptp() / x.size
     n = x.size

--- a/ionics_fits/models/utils.py
+++ b/ionics_fits/models/utils.py
@@ -85,16 +85,19 @@ def get_spectrum(
     """Returns the frequency spectrum (Fourier transform) of a dataset.
 
     :param x: x-axis data
-    :param y: y-axis data. For models with multiple y channels, this should contain
-        data from a single channel only.
+    :param y: y-axis data. For models with multiple y-channels, this must be
+        an array of shape (num_samples,) or (1, num_samples) containing data
+        from a single channel only.
     :param density_units: if `False` we apply normalization for narrow-band signals. If
         `True` we normalize for continuous distributions.
     :param trim_dc: if `True` we do not return the DC component.
     """
-    if y.ndim != 1 and y.shape[1] > 1:
+    if y.ndim != 1 and y.shape[0] != 1:
         raise ValueError(
-            f"{y.shape[1]} y channels were provided to a method which takes 1"
+            f"{y.shape[0]} y-channels were provided to a method which takes 1."
         )
+    # Ensure that y is a 1D array
+    y = np.squeeze(y)
 
     dx = x.ptp() / x.size
     n = x.size

--- a/test/common.py
+++ b/test/common.py
@@ -148,7 +148,7 @@ def check_single_param_set(
         )
 
     if config.residual_tol is not None and not is_close(
-        y, fit.evaluate()[1], config.residual_tol
+        y, fit.evaluate(transpose_and_squeeze=False)[1], config.residual_tol
     ):
         if config.plot_failures:
             _plot(
@@ -182,9 +182,9 @@ def _plot(
 
     _, ax = plt.subplots(fit.model.get_num_y_channels(), 2)
     for ch in range(fit.model.get_num_y_channels()):
-        y_model_ch = y_model[:, ch]
-        y_fit_ch = y_fit[:, ch]
-        y_heuristic_ch = y_heuristic[:, ch]
+        y_model_ch = y_model[ch]
+        y_fit_ch = y_fit[ch]
+        y_heuristic_ch = y_heuristic[ch]
 
         if fit.model.get_num_y_channels() == 1:
             ax = np.expand_dims(ax, axis=0)
@@ -259,9 +259,9 @@ def check_multiple_param_sets(
 
     test_params = dict(test_params)
 
-    def walk_params(remaining, scaned):
+    def walk_params(remaining, scanned):
         remaining = dict(remaining)
-        scaned = dict(scaned)
+        scanned = dict(scanned)
 
         param, values = remaining.popitem()
 
@@ -269,14 +269,14 @@ def check_multiple_param_sets(
             values = [values]
 
         for value in values:
-            scaned[param] = value
+            scanned[param] = value
             if remaining != {}:
-                walk_params(remaining, scaned)
+                walk_params(remaining, scanned)
             else:
                 check_single_param_set(
                     x=x,
                     model=model,
-                    test_params=scaned,
+                    test_params=scanned,
                     config=config,
                     fitter_cls=fitter_cls,
                 )

--- a/test/common.py
+++ b/test/common.py
@@ -148,7 +148,7 @@ def check_single_param_set(
         )
 
     if config.residual_tol is not None and not is_close(
-        y, fit.evaluate(transpose_and_squeeze=False)[1], config.residual_tol
+        y, fit.evaluate()[1], config.residual_tol
     ):
         if config.plot_failures:
             _plot(

--- a/test/test_aggregate_model.py
+++ b/test/test_aggregate_model.py
@@ -35,7 +35,7 @@ def test_aggregate_model_func(plot_failures):
 
     y_aggregate = model.func(x, params)
 
-    success = np.abs(np.max(np.stack((y_line, y_triangle)).T - y_aggregate)) < 1e-10
+    success = np.abs(np.max(np.vstack((y_line, y_triangle)) - y_aggregate)) < 1e-10
 
     if plot_failures and not success:
         _, ax = plt.subplots(2, 1)

--- a/test/test_repeated_model.py
+++ b/test/test_repeated_model.py
@@ -66,8 +66,8 @@ def test_repeated_model(plot_failures):
 
     y = model.func(w, params)
 
-    if y.shape != (len(w), 4):
-        raise ValueError("Incorrect y shape for repeated model")
+    if y.shape != (4, len(w)):
+        raise ValueError("Incorrect y-shape for repeated model.")
 
     common.check_multiple_param_sets(
         w,


### PR DESCRIPTION
This PR makes a major breaking change to ionics_fits as it changes the ordering of axes in arrays for y-axis data. The new ordering is `(num_y_channels, num_samples)`. This fixes the problems mentioned in https://github.com/OxIonics/ionics_fits/issues/97, see also that issue for a more general discussion.

The main code changes resulting from this decision are as follows:
-) Model functions with more than one y-channel now return y-data array with new shape
-) Fitter now requires observed y-data to be passed correctly with new shape and assumes that all models return data in the new shape
-) Function annotations for all models and fitter functions have been updated
-) Because only one independent variable is currently supported, the fitter always stores x-axis data as a 1D array. Even in the previous version, an error was thrown whenever the fitter was passed x-axis data that was not a 1D array. Since one or more y-channels (and corresponding sigma-channels) are supported, the fitter internally always uses and stores y-axis data (and sigma) data as 2D arrays.
-) As a result, y-data passed from fitter to models for parameter estimation are 2D, even for models that only contain a single y-channel. Therefore, in `estimate_parameters` for all models with just a single y-channel, have added a line to squeeze the y-array to make sure it is 1D.
-) In order to be able to use results from fitting for plotting, the `Fitter.evaluate()` method now takes an optional keyword argument called `transpose_and_squeeze`. This ensures that arrays returned are compatible with the `plot()` function of matplotlib. Squeezing is required because `plot()` requires data to be contained along columns and does not produce the desired result when using arrays of shape `(1, n_samples)`.

Apart from these changes, I have also modified the `Model.get_num_y_channels()` method to raise `NotImplementedError` to ensure that subclasses define this method. I ran into a problem where `MappedModel` for a model with multiple y-channels did not return the correct number of channels because the mapped model did not call `inner.get_num_y_channels()` and instead silently took the default of 1 from `Model.get_num_y_channels()`.

I have run `poe test`, all tests pass successfully.

One remaining issue is that strictly speaking, our function annotation for `Fitter.__init__()` is not quite correct. We currently allow the y-axis data for these models to be either 1D or 2D, but the annotation `y: ArrayLike[("num_y_channels", "num_samples"), np.float64]`, says it should only be 2D. Similarly, the annotations for `estimate_parameters` methods incorrectly say they only expect 1D arrays.