### PR TITLE
Add tests for benchmarking model

### DIFF
--- a/ionics_fits/models/benchmarking.py
+++ b/ionics_fits/models/benchmarking.py
@@ -57,6 +57,10 @@ class Benchmarking(Model):
         self.alpha = 2**num_qubits / (2**num_qubits - 1)
         super().__init__(parameters=_generate_benchmarking_parameters(num_qubits))
 
+    def get_num_y_channels(self) -> int:
+        """Return the number of y-channels supported by the model."""
+        return 1
+
     def func(
         self, x: Array[("num_samples",), np.float64], params: Dict[str, float]
     ) -> Array[("num_samples",), np.float64]:
@@ -89,6 +93,9 @@ class Benchmarking(Model):
         :param model_parameters: dictionary mapping model parameter names to their
             metadata, rescaled if allowed.
         """
+        # Ensure that y is a 1D array
+        y = np.squeeze(y)
+
         model_parameters["p"].heuristic = 1.0
         model_parameters["y0"].heuristic = max(y)
         model_parameters["y_inf"].heuristic = 1 / 2**self.num_qubits

--- a/test/fuzz.py
+++ b/test/fuzz.py
@@ -7,6 +7,7 @@ import traceback
 
 from . import (
     common,
+    test_benchmarking,
     test_exponential,
     test_gaussian,
     test_lorentzian,
@@ -24,6 +25,7 @@ logger = logging.getLogger(__name__)
 if __name__ == "__main__":
 
     targets = {
+        "benchmarking": test_benchmarking.fuzz_benchmarking,
         "exponential": test_exponential.fuzz_exponential,
         "gaussian": test_gaussian.fuzz_gaussian,
         "lorentzian": test_lorentzian.fuzz_lorentzian,

--- a/test/test_benchmarking.py
+++ b/test/test_benchmarking.py
@@ -1,0 +1,42 @@
+import numpy as np
+
+import ionics_fits as fits
+from . import common
+
+
+def test_benchmarking(plot_failures):
+    """Test for benchmarking.Benchmarking"""
+    x = np.linspace(0, 1000, 300)
+    params = {"p": [0.1, 0.3, 0.9], "y0": [0.9, 0.99], "y_inf": 1 / 2**2}
+    model = fits.models.Benchmarking(num_qubits=2)
+    common.check_multiple_param_sets(
+        x,
+        model,
+        params,
+        common.TestConfig(plot_failures=plot_failures),
+    )
+
+
+def fuzz_benchmarking(
+    num_trials: int,
+    stop_at_failure: bool,
+    test_config: common.TestConfig,
+) -> float:
+    x = np.linspace(0, 1000, 300)
+    fuzzed_params = {
+        "p": (0.1, 0.3),
+        "y0": (0.9, 0.99),
+    }
+    static_params = {"y_inf": 1 / 2**2}
+
+    return common.fuzz(
+        x=x,
+        model=fits.models.Benchmarking(num_qubits=2),
+        static_params=static_params,
+        fuzzed_params=fuzzed_params,
+        test_config=test_config,
+        fitter_cls=None,
+        num_trials=num_trials,
+        stop_at_failure=stop_at_failure,
+        param_generator=None,
+    )


### PR DESCRIPTION
When the benchmarking model was originally created, no tests were added, which meant we didn't catch corresponding errors.