### PR TITLE
Fix handling of initial internal state for laser flop fitting

### DIFF
--- a/ionics_fits/models/laser_rabi.py
+++ b/ionics_fits/models/laser_rabi.py
@@ -98,8 +98,12 @@ def make_laser_flop(base_class, distribution_fun):
             self.n_max = n_max
 
             n = np.arange(self.n_max + 1)
-            self._n_min = n_min = np.minimum(n, n + self.sideband_index)
-            n_max = np.maximum(n, n + self.sideband_index)
+            if self.start_excited:
+                self._n_min = n_min = np.minimum(n, n - self.sideband_index)
+                n_max = np.maximum(n, n - self.sideband_index)
+            else:
+                self._n_min = n_min = np.minimum(n, n + self.sideband_index)
+                n_max = np.maximum(n, n + self.sideband_index)
 
             # sqrt(n_min!/n_max!)
             self.fact = np.exp(
@@ -157,7 +161,10 @@ def make_laser_flop(base_class, distribution_fun):
                 angular frequency of driving field. They must have shapes such
                 that they are broadcastable.
             """
-            # coupling between |g>|n> and |e>|n+sideband_index>
+            # Rabi frequency as function of Fock state which the ion occupies
+            # initially. If the ion starts in |g>, corresponds to coupling between
+            # |g>|n> and |e>|n+sideband_index>. If the ion starts in |e>, corresponds
+            # to coupling between |g>|n-sideband_index> and |e>|n>.
             omega_vec = (
                 omega
                 * np.exp(-0.5 * np.power(eta, 2))


### PR DESCRIPTION
This PR addresses the error mentioned in https://github.com/OxIonics/ionics_fits/issues/101.

The model for laser Rabi flops applies to coupling between states $\ket{g}\ket{n}$ and $\ket{e}\ket{n + s}$, where the variable $s$ describes the change in motional state _when the ion starts in the internal ground state_ and is called `sideband_index` in the model. So we are implicitly defining `sideband_index` to mean the change relative to $\ket{g}\ket{n}$. To calculate the transition probability averaged over the distribution of initial Fock states, we calculate the Rabi frequency $\Omega_{n, n+s}$ for each initial Fock state $\ket{n}$ and store it in `omega_vec`. However, when the ion starts in the excited state, the variable $n$ describes the motional state connected with the excited internal state. Therefore, we need the coupling between states $\ket{g}\ket{n - s}$ and $\ket{e}\ket{n}$. The corresponding Rabi frequencies $\Omega_{n-s, n}$ are not the same as $\Omega_{n, n+s}$.

Probably the most intuitive way to fix this (which I have implemented in this PR) is to explicitly set the Fock states that are coupled for the chosen `sideband_index` depending on whether the ion starts in $\ket{g}$ or $\ket{e}$. If the ion initially occupies $\ket{g}$, then the initial motional state $\ket{n}$ is coupled to $\ket{n + s}$. If it occupies $\ket{e}$, then the initial motional state $\ket{n}$ is coupled to $\ket{n - s}$.