### PR TITLE
Molmer-Sorensen model: add derived parameter for detuning to complete loop

### DIFF
--- a/ionics_fits/models/molmer_sorensen.py
+++ b/ionics_fits/models/molmer_sorensen.py
@@ -50,9 +50,9 @@ class MolmerSorensen(Model):
             default)
 
     Derived parameters:
-        - f_0: resonance frequency offset
+        - f_0: resonance frequency offset (Hz)
 
-    All frequencies are in angular units.
+    All frequencies are in angular units unless stated otherwise.
     """
 
     def __init__(self, num_qubits: int, start_excited: bool, walsh_idx: int):
@@ -290,9 +290,9 @@ class MolmerSorensenFreq(MolmerSorensen):
     varied. The pulse duration is specified using a new `t_pulse` model
     parameter.
 
-    Derived parameters in addition to those inherited from `MolmerSorensen`:
-        - f_loop: frequency at which the loop in motional phase space closes
-            at the end of the pulse.
+    Derived parameters:
+        - f_loop_{n}: frequency offset of nth loop closure (Hz) for n = [1, 5]
+
     """
 
     def __init__(self, num_qubits: int, start_excited: bool, walsh_idx: int):
@@ -421,13 +421,12 @@ class MolmerSorensenFreq(MolmerSorensen):
             x, y, fitted_params, fit_uncertainties
         )
 
-        # Detuning required for loop closure at end of pulse
-        derived_params["f_loop"] = (self.walsh_idx + 1) / fitted_params[
-            "t_pulse"
-        ] + derived_params["f_0"]
-        derived_uncertainties["f_loop"] = np.sqrt(
-            ((self.walsh_idx + 1) * fit_uncertainties["t_pulse"]) ** 2
-            + derived_uncertainties["f_0"] ** 2
-        )
-
+        for n in range(1, 6):
+            derived_params[f"f_loop_{n}"] = (
+                n / fitted_params["t_pulse"] + derived_params["f_0"]
+            )
+            derived_uncertainties[f"f_loop_{n}"] = np.sqrt(
+                (n * fit_uncertainties["t_pulse"]) ** 2
+                + derived_uncertainties["f_0"] ** 2
+            )
         return derived_params, derived_uncertainties

--- a/ionics_fits/models/molmer_sorensen.py
+++ b/ionics_fits/models/molmer_sorensen.py
@@ -402,3 +402,25 @@ class MolmerSorensenFreq(MolmerSorensen):
             best = np.argmin(costs)
             model_parameters["omega"].heuristic = omegas[best]
             model_parameters["t_pulse"].heuristic = t_pulses[best]
+
+    def calculate_derived_params(
+        self,
+        x: Array[("num_samples",), np.float64],
+        y: Array[("num_y_channels", "num_samples"), np.float64],
+        fitted_params: Dict[str, float],
+        fit_uncertainties: Dict[str, float],
+    ) -> Tuple[Dict[str, float], Dict[str, float]]:
+        derived_params, derived_uncertainties = super().calculate_derived_params(
+            x, y, fitted_params, fit_uncertainties
+        )
+
+        # Detuning required for loop closure at end of pulse
+        derived_params["f_loop"] = (self.walsh_idx + 1) / fitted_params[
+            "t_pulse"
+        ] + derived_params["f_0"]
+        derived_uncertainties["f_loop"] = np.sqrt(
+            ((self.walsh_idx + 1) * fit_uncertainties["t_pulse"]) ** 2
+            + derived_uncertainties["f_0"] ** 2
+        )
+
+        return derived_params, derived_uncertainties

--- a/ionics_fits/models/molmer_sorensen.py
+++ b/ionics_fits/models/molmer_sorensen.py
@@ -45,9 +45,12 @@ class MolmerSorensen(Model):
 
     Model parameters:
         - omega: sideband Rabi frequency
-        - w_0: resonance frequency offset
+        - w_0: angular resonance frequency offset
         - n_bar: average initial occupancy of the motional mode (fixed to 0 by
             default)
+
+    Derived parameters:
+        - f_0: resonance frequency offset
 
     All frequencies are in angular units.
     """
@@ -286,6 +289,10 @@ class MolmerSorensenFreq(MolmerSorensen):
     when the gate duration is kept fixed and only the interaction detuning is
     varied. The pulse duration is specified using a new `t_pulse` model
     parameter.
+
+    Derived parameters in addition to those inherited from `MolmerSorensen`:
+        - f_loop: frequency at which the loop in motional phase space closes
+            at the end of the pulse.
     """
 
     def __init__(self, num_qubits: int, start_excited: bool, walsh_idx: int):


### PR DESCRIPTION
This PR adds the detuning required for closure of motional loop at end of pulse as a derived parameter to the Molmer-Sorensen model. The detuning required for loop closure does not depend on the Rabi frequency, only the pulse duration, which is taken from the fitted value. Note that there are several detunings at which motional loops close at end of pulse, the derived parameter used here corresponds to the lowest positive detuning at which this occurs, taking into account the Walsh index of the model.

I'm open for changes to the name of the derived parameter. I decided not to call it `f_gate` since it is not the optimal value of a two-qubit gate for the given fit, that would also take into account the fitted Rabi frequency. Rather, the derived parameter here is just the point where the loop in phase space closes for the duration used in the experiment. Checking the populations of `P_gg` and `P_ee` at that point then allows inferring whether the gate duration is correct, which is useful in practice. Besides, for a single qubit, there is no optimal "gate detuning" anyway.