### PR TITLE
Design refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ example dataset in the issue).
 Currently this project is a MVP and many of the heuristics need some work. Expect there
 to be cases where we could easily do better. Please report them where you find them!
 
+Helper tools for writing heuristics are located in [`models.heuristics`](../master/ionics_fits/models/heuristics.py).
+
 ## Validation
 
 It's not enough to just fit the data, we want to know if we can trust the fit results

--- a/ionics_fits/MLE.py
+++ b/ionics_fits/MLE.py
@@ -49,12 +49,18 @@ class MLEFitter(Fitter):
         """
         self.step_size = step_size
 
-        # https://github.com/OxIonics/ionics_fits/issues/105
-        model = copy.deepcopy(model)
-        model.can_rescale = lambda x_scale, y_scale: False
-
         if np.any(y < 0) or np.any(y > 1):
             raise RuntimeError("y values must lie between 0 and 1")
+
+        # Since we interpret the y-axis as a probability distribution, it should not be
+        # rescaled
+        def can_rescale() -> Tuple[bool, bool]:
+            rescale_x = self._can_rescale()[0]
+            return rescale_x, False
+
+        model = copy.deepcopy(model)
+        self._can_rescale = model.can_rescale
+        model.can_rescale = can_rescale
 
         super().__init__(x=x, y=y, model=model)
 

--- a/ionics_fits/MLE.py
+++ b/ionics_fits/MLE.py
@@ -42,7 +42,8 @@ class MLEFitter(Fitter):
         :param y: y-axis data
         :param model: the model function to fit to. The model's parameter dictionary is
             used to configure the fit (set parameter bounds etc). Modify this before
-            fitting to change the fit behaviour from the model class' defaults.
+            fitting to change the fit behaviour from the model class' defaults. The
+            model is (deep) copied and stored as an attribute.
         :param step_size: step size used when calculating the log likelihood's Hessian
             as part of finding the fitted parameter standard errors. Where finite
             parameter bounds are provided, they are used to scale the step size

--- a/ionics_fits/MLE.py
+++ b/ionics_fits/MLE.py
@@ -51,8 +51,7 @@ class MLEFitter(Fitter):
 
         # https://github.com/OxIonics/ionics_fits/issues/105
         model = copy.deepcopy(model)
-        for parameter in model.parameters.values():
-            parameter.scale_func = lambda x_scale, y_scale, _: None
+        model.can_rescale = lambda x_scale, y_scale: False
 
         if np.any(y < 0) or np.any(y > 1):
             raise RuntimeError("y values must lie between 0 and 1")

--- a/ionics_fits/binomial.py
+++ b/ionics_fits/binomial.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Callable, Optional, TYPE_CHECKING
+from typing import Callable, Dict, Optional, TYPE_CHECKING
 
 import numpy as np
 from scipy import stats
@@ -39,6 +39,7 @@ class BinomialFitter(MLEFitter):
         num_trials: int,
         model: Model,
         step_size: float = 1e-4,
+        minimizer_args: Optional[Dict] = None,
     ):
         """Fits a model to a dataset and stores the results.
 
@@ -49,9 +50,13 @@ class BinomialFitter(MLEFitter):
             fitting to change the fit behaviour from the model class' defaults.
         :param num_trials: number of Bernoulli trails for each sample
         :param step_size: see :class MLEFitter:
+        :param minimizer_args: optional dictionary of keyword arguments to be passed
+            into scipy.optimize.minimize.
         """
         self.num_trials = num_trials
-        super().__init__(x=x, y=y, model=model, step_size=step_size)
+        super().__init__(
+            x=x, y=y, model=model, step_size=step_size, minimizer_args=minimizer_args
+        )
 
     def log_liklihood(
         self,

--- a/ionics_fits/binomial.py
+++ b/ionics_fits/binomial.py
@@ -47,7 +47,8 @@ class BinomialFitter(MLEFitter):
         :param y: y-axis data
         :param model: the model function to fit to. The model's parameter dictionary is
             used to configure the fit (set parameter bounds etc). Modify this before
-            fitting to change the fit behaviour from the model class' defaults.
+            fitting to change the fit behaviour from the model class' defaults. The
+            model is (deep) copied and stored as an attribute.
         :param num_trials: number of Bernoulli trails for each sample
         :param step_size: see :class MLEFitter:
         :param minimizer_args: optional dictionary of keyword arguments to be passed

--- a/ionics_fits/common.py
+++ b/ionics_fits/common.py
@@ -558,20 +558,6 @@ class Model:
         x0 = x0 if x0 > min(x) else x0 + x.ptp()
         return x0
 
-    def get_initial_values(
-        self, model_parameters: Optional[Dict[str, ModelParameter]] = None
-    ) -> Dict[str, float]:
-        """Returns a dictionary mapping model parameter names to their initial values.
-
-        :param model_parameters: optional dictionary mapping model parameter names to
-           :class ModelParameter:s
-        """
-        model_paramers = model_parameters or self.parameters
-        return {
-            param: param_data.get_initial_value()
-            for param, param_data in model_paramers.items()
-        }
-
 
 class Fitter:
     """Base class for fitters.

--- a/ionics_fits/common.py
+++ b/ionics_fits/common.py
@@ -441,7 +441,8 @@ class Fitter:
         :param y: y-axis data
         :param model: the model function to fit to. The model's parameter dictionary is
             used to configure the fit (set parameter bounds etc). Modify this before
-            fitting to change the fit behaviour from the model class' defaults.
+            fitting to change the fit behaviour from the model class' defaults. The
+            model is (deep) copied and stored as an attribute.
         """
         self.model = copy.deepcopy(model)
 
@@ -510,9 +511,7 @@ class Fitter:
         self.model.estimate_parameters(x_scaled, y_scaled)
 
         for param, param_data in self.model.parameters.items():
-            try:
-                param_data.get_initial_value()
-            except ValueError:
+            if not param_data.has_initial_value():
                 raise RuntimeError(
                     "No fixed_to, user_estimate or heuristic specified"
                     f" for parameter `{param}`."

--- a/ionics_fits/common.py
+++ b/ionics_fits/common.py
@@ -152,8 +152,10 @@ class Model:
             `self.parameters` and may be modified after construction to change the model
             behaviour during fitting (e.g. to change the bounds, fixed parameters, etc).
         :param internal_parameters: optional list of "internal" model parameters, which
-            are not exposed to the user as arguments of :meth func:. These are typically
-            used by models which encapsulate / modify the behaviour of other models.
+            are not exposed to the user as arguments of :meth func:. Internal parameters
+            are rescaled in the same way as regular model parameters, but are not
+            otherwise used by :class Model:. These are typically used by models which
+            encapsulate / modify the behaviour of other models.
         """
         if parameters is None:
             spec = inspect.getfullargspec(self._func)

--- a/ionics_fits/common.py
+++ b/ionics_fits/common.py
@@ -169,6 +169,10 @@ class ModelParameter:
         """
         if self.fixed_to is not None:
             value = self.fixed_to
+            if self.user_estimate is not None:
+                raise ValueError(
+                    "User estimates must not be provided for fixed parameters"
+                )
         elif self.user_estimate is not None:
             value = self.user_estimate
         elif self.heuristic is not None:

--- a/ionics_fits/common.py
+++ b/ionics_fits/common.py
@@ -266,7 +266,6 @@ class Model:
         self,
         x: Array[("num_samples",), np.float64],
         y: Array[("num_y_channels", "num_samples"), np.float64],
-        model_parameters: Dict[str, ModelParameter],
     ):
         """Set heuristic values for model parameters.
 
@@ -647,7 +646,7 @@ class Fitter:
         x_scaled = self.x / self.x_scale
         y_scaled = self.y / self.y_scale
 
-        scaled_model.estimate_parameters(x_scaled, y_scaled, scaled_model.parameters)
+        scaled_model.estimate_parameters(x_scaled, y_scaled)
 
         for param, param_data in scaled_model.parameters.items():
             try:

--- a/ionics_fits/common.py
+++ b/ionics_fits/common.py
@@ -274,16 +274,11 @@ class Model:
         `user_estimate` attributes) to find initial guesses for other parameters.
 
         The datasets must be sorted in order of increasing x-axis values and must not
-        contain any infinite or nan values. If all parameters of the model allow
-        rescaling, then `x`, `y` and `model_parameters` will contain rescaled values.
-
-        TODO: this should act directly on self.model_parameters rather than taking
-        model parameters as an argument (this is a hangover from an old design)
+        contain any infinite or nan values. If the model allows rescaling then rescaled
+        units will be used everywhere (`x` and `y` as well as parameter values).
 
         :param x: x-axis data, rescaled if allowed.
         :param y: y-axis data, rescaled if allowed.
-        :param model_parameters: dictionary mapping model parameter names to their
-            metadata, rescaled if allowed.
         """
         raise NotImplementedError
 

--- a/ionics_fits/models/__init__.py
+++ b/ionics_fits/models/__init__.py
@@ -2,6 +2,7 @@ from .containers import AggregateModel, RepeatedModel
 from .benchmarking import Benchmarking
 from .exponential import Exponential
 from .gaussian import Gaussian
+from . import heuristics
 from .laser_rabi import (
     LaserFlopFreqCoherent,
     LaserFlopFreqSqueezed,

--- a/ionics_fits/models/benchmarking.py
+++ b/ionics_fits/models/benchmarking.py
@@ -47,6 +47,7 @@ class Benchmarking(Model):
     def can_rescale(self) -> Tuple[bool, bool]:
         return False, True
 
+    # pytype: disable=invalid-annotation
     def _func(
         self,
         x: Array[("num_samples",), np.float64],
@@ -65,6 +66,8 @@ class Benchmarking(Model):
     ) -> Array[("num_samples",), np.float64]:
         y = (y0 - y_inf) * p**x + y_inf
         return y
+
+    # pytype: enable=invalid-annotation
 
     def estimate_parameters(
         self,

--- a/ionics_fits/models/benchmarking.py
+++ b/ionics_fits/models/benchmarking.py
@@ -76,29 +76,13 @@ class Benchmarking(Model):
         self,
         x: Array[("num_samples",), np.float64],
         y: Array[("num_samples",), np.float64],
-        model_parameters: Dict[str, ModelParameter],
     ):
-        """Set heuristic values for model parameters.
-
-        Typically called during `Fitter.fit`. This method may make use of information
-        supplied by the user for some parameters (via the `fixed_to` or
-        `user_estimate` attributes) to find initial guesses for other parameters.
-
-        The datasets must be sorted in order of increasing x-axis values and must not
-        contain any infinite or nan values. If all parameters of the model allow
-        rescaling, then `x`, `y` and `model_parameters` will contain rescaled values.
-
-        :param x: x-axis data, rescaled if allowed.
-        :param y: y-axis data, rescaled if allowed.
-        :param model_parameters: dictionary mapping model parameter names to their
-            metadata, rescaled if allowed.
-        """
         # Ensure that y is a 1D array
         y = np.squeeze(y)
 
-        model_parameters["p"].heuristic = 1.0
-        model_parameters["y0"].heuristic = max(y)
-        model_parameters["y_inf"].heuristic = 1 / 2**self.num_qubits
+        self.parameters["p"].heuristic = 1.0
+        self.parameters["y0"].heuristic = max(y)
+        self.parameters["y_inf"].heuristic = 1 / 2**self.num_qubits
 
     def calculate_derived_params(
         self,

--- a/ionics_fits/models/benchmarking.py
+++ b/ionics_fits/models/benchmarking.py
@@ -9,6 +9,12 @@ if TYPE_CHECKING:
     num_samples = float
 
 
+def _p_scale_func(x_scale: float, y_scale: float) -> float:
+    if x_scale != 1.0:
+        raise RuntimeError("Benchmarking model cannot be rescaled along x")
+    return 1
+
+
 class Benchmarking(Model):
     """Benchmarking success probability decay model
 
@@ -38,15 +44,13 @@ class Benchmarking(Model):
     def get_num_y_channels(self) -> int:
         return 1
 
-    def can_rescale(self, x_scale: float, y_scale: float) -> bool:
-        return False
+    def can_rescale(self) -> Tuple[bool, bool]:
+        return False, True
 
     def _func(
         self,
         x: Array[("num_samples",), np.float64],
-        p: ModelParameter(
-            lower_bound=0.0, upper_bound=1.0, scale_func=common.scale_undefined
-        ),
+        p: ModelParameter(lower_bound=0.0, upper_bound=1.0, scale_func=_p_scale_func),
         y0: ModelParameter(
             lower_bound=0.0,
             upper_bound=1.0,

--- a/ionics_fits/models/containers.py
+++ b/ionics_fits/models/containers.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
 class AggregateModel(Model):
     """Model formed by aggregating one or more models.
-    
+
     Aggregate models are useful for situations where one wants to analyse multiple
     models simultaneously, for example in automated tooling (e.g. ndscan
     OnlineAnalyses). In the future their functionality will be expanded to allow making

--- a/ionics_fits/models/containers.py
+++ b/ionics_fits/models/containers.py
@@ -289,17 +289,22 @@ class RepeatedModel(Model):
         # calculate statistical results
         def add_statistics(values, uncertainties, param_names):
             for param_name in param_names:
-                param_values = [
-                    values[f"{param_name}_{idx}"] for idx in range(self.num_repetitions)
-                ]
-                param_uncerts = [
-                    uncertainties[f"{param_name}_{idx}"]
-                    for idx in range(self.num_repetitions)
-                ]
+                param_values = np.array(
+                    [
+                        values[f"{param_name}_{idx}"]
+                        for idx in range(self.num_repetitions)
+                    ]
+                )
+                param_uncerts = np.array(
+                    [
+                        uncertainties[f"{param_name}_{idx}"]
+                        for idx in range(self.num_repetitions)
+                    ]
+                )
 
                 derived_params[f"{param_name}_mean"] = np.mean(param_values)
                 derived_uncertainties[f"{param_name}_mean"] = (
-                    np.sqrt(np.sum(np.power(param_uncerts, 2))) / self.num_repetitions
+                    np.sqrt(np.sum(param_uncerts**2)) / self.num_repetitions
                 )
 
                 derived_params[f"{param_name}_peak_peak"] = np.ptp(param_values)

--- a/ionics_fits/models/containers.py
+++ b/ionics_fits/models/containers.py
@@ -56,13 +56,9 @@ class AggregateModel(Model):
     def get_num_y_channels(self) -> int:
         return len(self.models)
 
-    def can_rescale(self, x_scale: float, y_scale: float) -> bool:
-        return all(
-            [
-                model.can_rescale(x_scale=x_scale, y_scale=y_scale)
-                for _, model in self.models
-            ]
-        )
+    def can_rescale(self) -> Tuple[bool, bool]:
+        rescale_x, rescale_y = zip(*[model.can_rescale() for _, model in self.models])
+        return all(rescale_x), all(rescale_y)
 
     def func(
         self,
@@ -190,8 +186,8 @@ class RepeatedModel(Model):
     def get_num_y_channels(self) -> int:
         return self.num_repetitions * self.inner.get_num_y_channels()
 
-    def can_rescale(self, x_scale: float, y_scale: float) -> bool:
-        return self.inner.can_rescale(x_scale, y_scale)
+    def can_rescale(self) -> Tuple[bool, bool]:
+        return self.inner.can_rescale()
 
     def func(
         self,
@@ -395,8 +391,8 @@ class MappedModel(Model):
     def get_num_y_channels(self) -> int:
         return self.wrapped_model.get_num_y_channels()
 
-    def can_rescale(self, x_scale: float, y_scale: float) -> bool:
-        return self.wrapped_model.can_rescale(x_scale, y_scale)
+    def can_rescale(self) -> Tuple[bool, bool]:
+        return self.wrapped_model.can_rescale()
 
     def func(
         self, x: Array[("num_samples",), np.float64], param_values: Dict[str, float]

--- a/ionics_fits/models/containers.py
+++ b/ionics_fits/models/containers.py
@@ -13,7 +13,13 @@ if TYPE_CHECKING:
 
 
 class AggregateModel(Model):
-    """Model formed by aggregating one or more models"""
+    """Model formed by aggregating one or more models.
+    
+    Aggregate models are useful for situations where one wants to analyse multiple
+    models simultaneously, for example in automated tooling (e.g. ndscan
+    OnlineAnalyses). In the future their functionality will be expanded to allow making
+    parameters common to do joint fitting.
+    """
 
     def __init__(
         self,

--- a/ionics_fits/models/containers.py
+++ b/ionics_fits/models/containers.py
@@ -138,6 +138,11 @@ class RepeatedModel(Model):
 
     The `RepeatedModel` has multiple y-channels, corresponding to the repetitions of
     the wrapped model.
+
+    Repeated models allow multiple datasets to be analysed simultaneously. This is
+    useful, for example, when doing joint fits to datasets (using common parameters)
+    or in automated tooling (for example ndscan OnlineAnalyses) which needs a single
+    model for an entire dataset.
     """
 
     def __init__(

--- a/ionics_fits/models/exponential.py
+++ b/ionics_fits/models/exponential.py
@@ -50,31 +50,15 @@ class Exponential(Model):
         self,
         x: Array[("num_samples",), np.float64],
         y: Array[("num_samples",), np.float64],
-        model_parameters: Dict[str, ModelParameter],
     ):
-        """Set heuristic values for model parameters.
-
-        Typically called during `Fitter.fit`. This method may make use of information
-        supplied by the user for some parameters (via the `fixed_to` or
-        `user_estimate` attributes) to find initial guesses for other parameters.
-
-        The datasets must be sorted in order of increasing x-axis values and must not
-        contain any infinite or nan values. If all parameters of the model allow
-        rescaling, then `x`, `y` and `model_parameters` will contain rescaled values.
-
-        :param x: x-axis data, rescaled if allowed.
-        :param y: y-axis data, rescaled if allowed.
-        :param model_parameters: dictionary mapping model parameter names to their
-            metadata, rescaled if allowed.
-        """
         # Ensure that y is a 1D array
         y = np.squeeze(y)
 
         # Exponentials are generally pretty easy to fit so we keep the estimator simple
-        model_parameters["x_dead"].heuristic = 0
-        model_parameters["y0"].heuristic = y[0]
-        model_parameters["y_inf"].heuristic = y[-1]
-        model_parameters["tau"].heuristic = x.ptp()
+        self.parameters["x_dead"].heuristic = 0
+        self.parameters["y0"].heuristic = y[0]
+        self.parameters["y_inf"].heuristic = y[-1]
+        self.parameters["tau"].heuristic = x.ptp()
 
     def calculate_derived_params(
         self,

--- a/ionics_fits/models/exponential.py
+++ b/ionics_fits/models/exponential.py
@@ -26,8 +26,8 @@ class Exponential(Model):
     def get_num_y_channels(self) -> int:
         return 1
 
-    def can_rescale(self, x_scale: float, y_scale: float) -> bool:
-        return True
+    def can_rescale(self) -> Tuple[bool, bool]:
+        return True, True
 
     # pytype: disable=invalid-annotation
     def _func(

--- a/ionics_fits/models/gaussian.py
+++ b/ionics_fits/models/gaussian.py
@@ -55,23 +55,7 @@ class Gaussian(Model):
         self,
         x: Array[("num_samples",), np.float64],
         y: Array[("num_samples",), np.float64],
-        model_parameters: Dict[str, ModelParameter],
     ):
-        """Set heuristic values for model parameters.
-
-        Typically called during `Fitter.fit`. This method may make use of information
-        supplied by the user for some parameters (via the `fixed_to` or
-        `user_estimate` attributes) to find initial guesses for other parameters.
-
-        The datasets must be sorted in order of increasing x-axis values and must not
-        contain any infinite or nan values. If all parameters of the model allow
-        rescaling, then `x`, `y` and `model_parameters` will contain rescaled values.
-
-        :param x: x-axis data, rescaled if allowed.
-        :param y: y-axis data, rescaled if allowed.
-        :param model_parameters: dictionary mapping model parameter names to their
-            metadata, rescaled if allowed.
-        """
         # Ensure that y is a 1D array
         y = np.squeeze(y)
 
@@ -91,28 +75,28 @@ class Gaussian(Model):
         sigma = width / 2
         a = peak * np.pi * np.sqrt(2)
 
-        model_parameters["y0"].heuristic = np.mean([y[0], y[-1]])
-        y0 = model_parameters["y0"].get_initial_value()
+        self.parameters["y0"].heuristic = np.mean([y[0], y[-1]])
+        y0 = self.parameters["y0"].get_initial_value()
         peak_idx = np.argmax(np.abs(y - y0))
         y_peak = y[peak_idx]
         sgn = 1 if y_peak > y0 else -1
 
-        model_parameters["a"].heuristic = a * sgn
-        model_parameters["sigma"].heuristic = sigma
+        self.parameters["a"].heuristic = a * sgn
+        self.parameters["sigma"].heuristic = sigma
 
         cut_off = 2 * omega[np.argmin(np.abs(abs_spectrum - W))]
 
         x0 = self.find_x_offset_sym_peak(
             x=x,
             y=y,
-            parameters=model_parameters,
+            parameters=self.parameters,
             omega=omega,
             spectrum=spectrum,
             omega_cut_off=cut_off,
             test_pts=x[peak_idx],
         )
 
-        model_parameters["x0"].heuristic = x0
+        self.parameters["x0"].heuristic = x0
 
     def calculate_derived_params(
         self,

--- a/ionics_fits/models/gaussian.py
+++ b/ionics_fits/models/gaussian.py
@@ -31,8 +31,8 @@ class Gaussian(Model):
     def get_num_y_channels(self) -> int:
         return 1
 
-    def can_rescale(self, x_scale: float, y_scale: float) -> bool:
-        return True
+    def can_rescale(self) -> Tuple[bool, bool]:
+        return True, True
 
     # pytype: disable=invalid-annotation
     def _func(

--- a/ionics_fits/models/gaussian.py
+++ b/ionics_fits/models/gaussian.py
@@ -1,6 +1,7 @@
 from typing import Dict, Tuple, TYPE_CHECKING
 import numpy as np
 
+from . import heuristics
 from .utils import get_spectrum
 from .. import common, Model, ModelParameter
 from ..utils import Array
@@ -86,10 +87,10 @@ class Gaussian(Model):
 
         cut_off = 2 * omega[np.argmin(np.abs(abs_spectrum - W))]
 
-        x0 = self.find_x_offset_sym_peak(
+        x0 = heuristics.find_x_offset_sym_peak(
+            model=self,
             x=x,
             y=y,
-            parameters=self.parameters,
             omega=omega,
             spectrum=spectrum,
             omega_cut_off=cut_off,

--- a/ionics_fits/models/gaussian.py
+++ b/ionics_fits/models/gaussian.py
@@ -2,7 +2,7 @@ from typing import Dict, Tuple, TYPE_CHECKING
 import numpy as np
 
 from .utils import get_spectrum
-from .. import Model, ModelParameter
+from .. import common, Model, ModelParameter
 from ..utils import Array
 
 
@@ -29,19 +29,19 @@ class Gaussian(Model):
     """
 
     def get_num_y_channels(self) -> int:
-        """Returns the number of y channels supported by the model"""
         return 1
+
+    def can_rescale(self, x_scale: float, y_scale: float) -> bool:
+        return True
 
     # pytype: disable=invalid-annotation
     def _func(
         self,
         x: Array[("num_samples",), np.float64],
-        x0: ModelParameter(scale_func=lambda x_scale, y_scale, _: x_scale),
-        y0: ModelParameter(scale_func=lambda x_scale, y_scale, _: y_scale),
-        a: ModelParameter(scale_func=lambda x_scale, y_scale, _: y_scale * x_scale),
-        sigma: ModelParameter(
-            lower_bound=0, scale_func=lambda x_scale, y_scale, _: x_scale
-        ),
+        x0: ModelParameter(scale_func=common.scale_x),
+        y0: ModelParameter(scale_func=common.scale_y),
+        a: ModelParameter(scale_func=common.scale_power(x_power=1, y_power=1)),
+        sigma: ModelParameter(lower_bound=0, scale_func=common.scale_x),
     ) -> Array[("num_samples",), np.float64]:
         y = (
             a / (sigma * np.sqrt(2 * np.pi)) * np.exp(-0.5 * ((x - x0) / sigma) ** 2)
@@ -105,21 +105,6 @@ class Gaussian(Model):
         fitted_params: Dict[str, float],
         fit_uncertainties: Dict[str, float],
     ) -> Tuple[Dict[str, float], Dict[str, float]]:
-        """
-        Returns dictionaries of values and uncertainties for the derived model
-        parameters (parameters which are calculated from the fit results rather than
-        being directly part of the fit) based on values of the fitted parameters and
-        their uncertainties.
-
-        :param x: x-axis data
-        :param y: y-axis data
-        :param: fitted_params: dictionary mapping model parameter names to their
-            fitted values.
-        :param fit_uncertainties: dictionary mapping model parameter names to
-            their fit uncertainties.
-        :returns: tuple of dictionaries mapping derived parameter names to their
-            values and uncertainties.
-        """
         sigma = fitted_params["sigma"]
         a = fitted_params["a"]
 

--- a/ionics_fits/models/heuristics.py
+++ b/ionics_fits/models/heuristics.py
@@ -1,11 +1,73 @@
-from typing import TYPE_CHECKING
+from typing import Dict, Optional, Tuple, TYPE_CHECKING
 import numpy as np
-from ..utils import Array
+
+from .. import Model
+from ..utils import Array, ArrayLike
 
 
 if TYPE_CHECKING:
     num_samples = float
     num_y_channels = float
+    num_values = float
+    num_spectrum_pts = float
+
+
+def param_min_sqrs(
+    model: Model,
+    x: Array[("num_samples",), np.float64],
+    y: Array[("num_y_channels", "num_samples"), np.float64],
+    scanned_param: str,
+    scanned_param_values: ArrayLike["num_values", np.float64],
+    defaults: Optional[Dict[str, float]] = None,
+) -> Tuple[float, float]:
+    """Scans one model parameter while holding the others fixed to find the value
+    that gives the best fit to the data (minimum sum-squared residuals).
+
+    :param x: x-axis data
+    :param y: y-axis data
+    :param scanned_param: name of parameter to optimize
+    :param scanned_param_values: array of scanned parameter values to test
+    :param defaults: optional dictionary of fallback values to use for non-scanned
+      parameters which don't have heuristics set yet
+
+    :returns: tuple with the value from :param scanned_param_values: which results
+    in lowest residuals and the root-sum-squared residuals for that value.
+    """
+    defaults = defaults or {}
+    if not set(defaults.keys()).issubset(model.parameters.keys()):
+        raise ValueError("Defaults must be a subset of the model parameters")
+    if scanned_param in defaults.keys():
+        raise ValueError("The scanned parameter cannot have a default")
+
+    missing_values = [
+        param_name
+        for param_name, param_data in model.parameters.items()
+        if not param_data.has_initial_value()
+        and param_name != scanned_param
+        and param_name not in defaults.keys()
+    ]
+    if any(missing_values):
+        raise ValueError(f"No initial value specified for parameters: {missing_values}")
+
+    param_values = {
+        param: param_data.get_initial_value(default=defaults.get(param))
+        for param, param_data in model.parameters.items()
+        if param != scanned_param
+    }
+
+    scanned_param_values = np.asarray(scanned_param_values).squeeze()
+    costs = np.zeros_like(scanned_param_values)
+    for idx, value in np.ndenumerate(scanned_param_values):
+        param_values[scanned_param] = value
+        y_params = model.func(x, param_values)
+        costs[idx] = np.sqrt(np.sum(np.square(y - y_params)))
+
+    # handle a quirk of numpy indexing if only one value is passed in
+    if scanned_param_values.size == 1:
+        return float(scanned_param_values), float(costs)
+
+    opt = np.argmin(costs)
+    return float(scanned_param_values[opt]), float(costs[opt])
 
 
 def get_sym_x(
@@ -42,3 +104,142 @@ def get_sym_x(
         costs[point_num] = cost / var
 
     return x[window[np.argmin(costs)]]
+
+
+def find_x_offset_fft(
+    x: Array[("num_samples",), np.float64],
+    omega: Array[("num_spectrum_pts",), np.float64],
+    spectrum: Array[("num_spectrum_pts",), np.float64],
+    omega_cut_off: float,
+) -> float:
+    """Finds the x-axis offset of a dataset from the phase of an FFT.
+
+    This function uses the FFT shift theorem to extract the offset from the phase
+    slope of an FFT. At present it only supports models with a single y channel.
+
+    :param omega: FFT frequency axis
+    :param spectrum: complex FFT data. For models with multiple y channels, this
+      should contain data from a single channel only.
+    :param omega_cut_off: highest value of omega to use in offset estimation
+
+    :returns: an estimate of the x-axis offset
+    """
+    if spectrum.ndim != 1:
+        raise ValueError(f"Function only takes 1 y channel, not {spectrum.shape[1]}")
+
+    keep = omega < omega_cut_off
+    if np.sum(keep) < 2:
+        raise ValueError("Insufficient data below cut-off")
+
+    omega = omega[keep]
+    phi = np.unwrap(np.angle(spectrum[keep]))
+    phi -= phi[0]
+
+    p = np.polyfit(omega, phi, deg=1)
+
+    x0 = min(x) - p[0]
+    x0 = x0 if x0 > min(x) else x0 + x.ptp()
+    return x0
+
+
+def find_x_offset_sym_peak(
+    model: Model,
+    x: Array[("num_samples",), np.float64],
+    y: Array[("num_samples",), np.float64],
+    omega: Array[("num_spectrum_pts",), np.float64],
+    spectrum: Array[("num_spectrum_pts",), np.float64],
+    omega_cut_off: float,
+    test_pts: Optional[Array[("num_values",), np.float64]] = None,
+    x_offset_param_name: str = "x0",
+    y_offset_param_name: str = "y0",
+):
+    """Finds the x-axis offset for symmetric, peaked (maximum deviation from the
+    baseline occurs at the origin) functions.
+
+    This heuristic draws candidate x-offset points from three sources and picks the
+    best one (in the least-squares residuals sense). Sources:
+      - FFT shift theorem based on provided spectrum data
+      - Tests all points in the top quartile of deviation from the baseline
+      - Optionally, user-provided "test points", taken from another heuristic. This
+        allows the developer to combine the general-purpose heuristics here with
+        other heuristics which make use of more model-specific assumptions
+
+    :param model: the fit model
+    :param x: x-axis data
+    :param y: y-axis data. For models with multiple y channels, this should contain
+        data from a single channel only.
+    :param omega: FFT frequency axis
+    :param spectrum: complex FFT data. For models with multiple y channels, this
+      should contain data from a single channel only.
+    :param omega_cut_off: highest value of omega to use in offset estimation
+    :param test_pts: optional array of x-axis points to test
+    :param x_offset_param_name: name of the x-axis offset model parameter
+    :param y_offset_param_name: name of the y-axis offset model parameter
+
+    :returns: an estimate of the x-axis offset
+    """
+    if y.ndim != 1:
+        raise ValueError(
+            f"{y.shape[0]} y-channels were provided to a method which takes 1."
+        )
+
+    x0_candidates = np.array([])
+
+    if test_pts is not None:
+        x0_candidates = np.append(x0_candidates, test_pts)
+
+    try:
+        fft_candidate = find_x_offset_fft(
+            x=x, omega=omega, spectrum=spectrum, omega_cut_off=omega_cut_off
+        )
+        x0_candidates = np.append(x0_candidates, fft_candidate)
+    except ValueError:
+        pass
+
+    y0 = model.parameters[y_offset_param_name].get_initial_value()
+    deviations = np.argsort(np.abs(y - y0))
+    top_quartile_deviations = deviations[int(len(deviations) * 3 / 4) :]
+    deviations_candidates = x[top_quartile_deviations]
+    x0_candidates = np.append(x0_candidates, deviations_candidates)
+
+    best_x0, _ = param_min_sqrs(
+        model=model,
+        x=x,
+        y=y,
+        scanned_param=x_offset_param_name,
+        scanned_param_values=x0_candidates,
+    )
+    return best_x0
+
+
+def find_x_offset_sampling(
+    model: Model,
+    x: Array[("num_samples",), np.float64],
+    y: Array[("num_samples", "num_y_channels"), np.float64],
+    width: float,
+    x_offset_param_name: str = "x0",
+) -> float:
+    """Finds the x-axis offset of a dataset by stepping through a range of potential
+    offset values and picking the one that gives the lowest residuals.
+
+    This function takes a more brute-force approach by evaluating the model at a
+    range of offset values, picking the one that gives the lowest residuals. This
+    may be appropriate where one needs the estimate to be highly robust in the face
+    of noisy, irregularly sampled data.
+
+    :param x: x-axis data
+    :param y: y-axis data
+    :param width: width of the feature we're trying to find (e.g. FWHMH). Used to
+        pick the spacing between offset values to try.
+    :param x_offset_param_name: name of the x-axis offset parameter
+
+    :returns: an estimate of the x-axis offset
+    """
+    offsets = np.arange(min(x), max(x), width / 6)
+    return param_min_sqrs(
+        model=model,
+        x=x,
+        y=y,
+        scanned_param=x_offset_param_name,
+        scanned_param_values=offsets,
+    )[0]

--- a/ionics_fits/models/heuristics.py
+++ b/ionics_fits/models/heuristics.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, Tuple, TYPE_CHECKING
+from typing import cast, Dict, Optional, Tuple, TYPE_CHECKING
 import numpy as np
 
 from .. import Model
@@ -33,7 +33,7 @@ def param_min_sqrs(
     :returns: tuple with the value from :param scanned_param_values: which results
     in lowest residuals and the root-sum-squared residuals for that value.
     """
-    defaults = defaults or {}
+    defaults = cast(dict, defaults or {})
     if not set(defaults.keys()).issubset(model.parameters.keys()):
         raise ValueError("Defaults must be a subset of the model parameters")
     if scanned_param in defaults.keys():

--- a/ionics_fits/models/heuristics.py
+++ b/ionics_fits/models/heuristics.py
@@ -210,36 +210,3 @@ def find_x_offset_sym_peak(
         scanned_param_values=x0_candidates,
     )
     return best_x0
-
-
-def find_x_offset_sampling(
-    model: Model,
-    x: Array[("num_samples",), np.float64],
-    y: Array[("num_samples", "num_y_channels"), np.float64],
-    width: float,
-    x_offset_param_name: str = "x0",
-) -> float:
-    """Finds the x-axis offset of a dataset by stepping through a range of potential
-    offset values and picking the one that gives the lowest residuals.
-
-    This function takes a more brute-force approach by evaluating the model at a
-    range of offset values, picking the one that gives the lowest residuals. This
-    may be appropriate where one needs the estimate to be highly robust in the face
-    of noisy, irregularly sampled data.
-
-    :param x: x-axis data
-    :param y: y-axis data
-    :param width: width of the feature we're trying to find (e.g. FWHMH). Used to
-        pick the spacing between offset values to try.
-    :param x_offset_param_name: name of the x-axis offset parameter
-
-    :returns: an estimate of the x-axis offset
-    """
-    offsets = np.arange(min(x), max(x), width / 6)
-    return param_min_sqrs(
-        model=model,
-        x=x,
-        y=y,
-        scanned_param=x_offset_param_name,
-        scanned_param_values=offsets,
-    )[0]

--- a/ionics_fits/models/laser_rabi.py
+++ b/ionics_fits/models/laser_rabi.py
@@ -1,6 +1,6 @@
 import copy
 import inspect
-from typing import Dict, Tuple, TYPE_CHECKING
+from typing import Tuple, TYPE_CHECKING
 
 import numpy as np
 from scipy import special
@@ -207,19 +207,18 @@ def make_laser_flop(base_class, distribution_fun):
             self,
             x: Array[("num_samples",), np.float64],
             y: Array[("num_samples",), np.float64],
-            model_parameters: Dict[str, ModelParameter],
         ):
             # Pick sensible starting values which are usually good enough for the fit to
             # converge from.
-            model_parameters["eta"].heuristic = 0.1
-            if "n_bar" in model_parameters.keys():
-                model_parameters["n_bar"].heuristic = 1
-            if "alpha" in model_parameters.keys():
-                model_parameters["alpha"].heuristic = 1
-            if "zeta" in model_parameters.keys():
-                model_parameters["zeta"].heuristic = 1
+            self.parameters["eta"].heuristic = 0.1
+            if "n_bar" in self.parameters.keys():
+                self.parameters["n_bar"].heuristic = 1
+            if "alpha" in self.parameters.keys():
+                self.parameters["alpha"].heuristic = 1
+            if "zeta" in self.parameters.keys():
+                self.parameters["zeta"].heuristic = 1
 
-            super().estimate_parameters(x=x, y=y, model_parameters=model_parameters)
+            super().estimate_parameters(x=x, y=y)
 
     return LaserFlop
 

--- a/ionics_fits/models/laser_rabi.py
+++ b/ionics_fits/models/laser_rabi.py
@@ -171,11 +171,11 @@ def make_laser_flop(base_class, distribution_fun):
             # to coupling between |g>|n-sideband_index> and |e>|n>.
             omega_vec = (
                 omega
-                * np.exp(-0.5 * np.power(eta, 2))
-                * np.power(eta, np.abs(self.sideband_index))
+                * np.exp(-0.5 * eta**2)
+                * eta ** np.abs(self.sideband_index)
                 * self.fact
                 * special.eval_genlaguerre(
-                    self._n_min, np.abs(self.sideband_index), np.power(eta, 2)
+                    self._n_min, np.abs(self.sideband_index), eta**2
                 )
             )
 
@@ -187,12 +187,10 @@ def make_laser_flop(base_class, distribution_fun):
 
             # Transition probability for individual Fock state, given by
             #     P_transition = 1/2 * omega^2 / W^2 * [1 - exp(-t / tau) * cos(W * t)]
-            W = np.sqrt(np.power(omega, 2) + np.power(detuning, 2))
+            W = np.sqrt(omega**2 + detuning**2)
             P_trans = (
                 0.5
-                * np.power(
-                    np.divide(omega, W, out=np.zeros_like(W), where=(W != 0.0)), 2
-                )
+                * (np.divide(omega, W, out=np.zeros_like(W), where=(W != 0.0)) ** 2)
                 * (1 - np.exp(-t / tau) * np.cos(W * t))
             )
 

--- a/ionics_fits/models/laser_rabi.py
+++ b/ionics_fits/models/laser_rabi.py
@@ -11,7 +11,7 @@ from .quantum_phys import (
     thermal_state_probs,
 )
 from . import rabi
-from .. import ModelParameter
+from .. import common, ModelParameter
 from ..utils import Array
 
 
@@ -140,18 +140,22 @@ def make_laser_flop(base_class, distribution_fun):
             P_readout_e: ModelParameter(
                 lower_bound=0.0,
                 upper_bound=1.0,
-                scale_func=lambda x_scale, y_scale, _: y_scale,
+                scale_func=common.scale_y,
             ),
             P_readout_g: ModelParameter(
                 lower_bound=0.0,
                 upper_bound=1.0,
-                scale_func=lambda x_scale, y_scale, _: y_scale,
+                scale_func=common.scale_y,
             ),
-            eta: ModelParameter(lower_bound=0.0),
-            omega: ModelParameter(lower_bound=0.0),
-            tau: ModelParameter(lower_bound=0.0, fixed_to=np.inf),
-            t_dead: ModelParameter(lower_bound=0.0, fixed_to=0.0),
-            w_0: ModelParameter(),
+            eta: ModelParameter(lower_bound=0.0, scale_func=common.scale_invariant),
+            omega: ModelParameter(lower_bound=0.0, scale_func=common.scale_undefined),
+            tau: ModelParameter(
+                lower_bound=0.0, fixed_to=np.inf, scale_func=common.scale_undefined
+            ),
+            t_dead: ModelParameter(
+                lower_bound=0.0, fixed_to=0.0, scale_func=common.scale_undefined
+            ),
+            w_0: ModelParameter(scale_func=common.scale_undefined),
             **kwargs,  # Fock state distribution function parameters
         ) -> Array[("num_samples",), np.float64]:
             """

--- a/ionics_fits/models/lorentzian.py
+++ b/ionics_fits/models/lorentzian.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import Tuple, TYPE_CHECKING
 import numpy as np
 
 from .exponential import Exponential
@@ -28,8 +28,8 @@ class Lorentzian(Model):
     def get_num_y_channels(self) -> int:
         return 1
 
-    def can_rescale(self, x_scale: float, y_scale: float) -> bool:
-        return True
+    def can_rescale(self) -> Tuple[bool, bool]:
+        return True, True
 
     # pytype: disable=invalid-annotation
     def _func(

--- a/ionics_fits/models/lorentzian.py
+++ b/ionics_fits/models/lorentzian.py
@@ -1,9 +1,10 @@
 from typing import Tuple, TYPE_CHECKING
 import numpy as np
 
+from . import heuristics
 from .exponential import Exponential
 from .utils import get_spectrum
-from .. import common, NormalFitter, Model, ModelParameter
+from .. import common, Model, ModelParameter, NormalFitter
 from ..utils import Array
 
 
@@ -74,10 +75,10 @@ class Lorentzian(Model):
 
         cut_off = 2 * fit.values["tau"]
 
-        x0 = self.find_x_offset_sym_peak(
+        x0 = heuristics.find_x_offset_sym_peak(
+            model=self,
             x=x,
             y=y,
-            parameters=self.parameters,
             omega=omega,
             spectrum=spectrum,
             omega_cut_off=cut_off,

--- a/ionics_fits/models/lorentzian.py
+++ b/ionics_fits/models/lorentzian.py
@@ -3,7 +3,7 @@ import numpy as np
 
 from .exponential import Exponential
 from .utils import get_spectrum
-from .. import NormalFitter, Model, ModelParameter
+from .. import common, NormalFitter, Model, ModelParameter
 from ..utils import Array
 
 
@@ -26,19 +26,19 @@ class Lorentzian(Model):
     """
 
     def get_num_y_channels(self) -> int:
-        """Returns the number of y channels supported by the model"""
         return 1
+
+    def can_rescale(self, x_scale: float, y_scale: float) -> bool:
+        return True
 
     # pytype: disable=invalid-annotation
     def _func(
         self,
         x: Array[("num_samples",), np.float64],
-        x0: ModelParameter(scale_func=lambda x_scale, y_scale, _: x_scale),
-        y0: ModelParameter(scale_func=lambda x_scale, y_scale, _: y_scale),
-        a: ModelParameter(scale_func=lambda x_scale, y_scale, _: y_scale),
-        fwhmh: ModelParameter(
-            lower_bound=0, scale_func=lambda x_scale, y_scale, _: x_scale
-        ),
+        x0: ModelParameter(scale_func=common.scale_x),
+        y0: ModelParameter(scale_func=common.scale_y),
+        a: ModelParameter(scale_func=common.scale_y),
+        fwhmh: ModelParameter(lower_bound=0, scale_func=common.scale_x),
     ) -> Array[("num_samples",), np.float64]:
         y = a * fwhmh**2 / ((x - x0) ** 2 + fwhmh**2) + y0
         return y

--- a/ionics_fits/models/lorentzian.py
+++ b/ionics_fits/models/lorentzian.py
@@ -1,4 +1,4 @@
-from typing import Dict, TYPE_CHECKING
+from typing import TYPE_CHECKING
 import numpy as np
 
 from .exponential import Exponential
@@ -49,23 +49,7 @@ class Lorentzian(Model):
         self,
         x: Array[("num_samples",), np.float64],
         y: Array[("num_samples",), np.float64],
-        model_parameters: Dict[str, ModelParameter],
     ):
-        """Sets initial values for model parameters based on heuristics. Typically
-        called during `Fitter.fit`.
-
-        Heuristic results should be stored in :param model_parameters: using the
-        `ModelParameter`'s `heuristic` attribute. This ensures that all information
-        passed in by the user (fixed values, initial values, bounds) is used correctly.
-
-        The dataset must be sorted in order of increasing x-axis values and must not
-        contain any infinite or nan values.
-
-        :param x: x-axis data
-        :param y: y-axis data
-        :param model_parameters: dictionary mapping model parameter names to their
-            metadata.
-        """
         # Ensure that y is a 1D array
         y = np.squeeze(y)
 
@@ -77,27 +61,27 @@ class Lorentzian(Model):
         model.parameters["y_inf"].heuristic = 0.0
         fit = NormalFitter(omega, abs_spectrum, model)
 
-        model_parameters["y0"].heuristic = np.mean([y[0], y[-1]])
-        y0 = model_parameters["y0"].get_initial_value()
+        self.parameters["y0"].heuristic = np.mean([y[0], y[-1]])
+        y0 = self.parameters["y0"].get_initial_value()
 
         peak_idx = np.argmax(np.abs(y - y0))
         y_peak = y[peak_idx]
         sgn = 1 if y_peak > y0 else -1
 
-        model_parameters["fwhmh"].heuristic = 1 / fit.values["tau"]
-        fwhmh = model_parameters["fwhmh"].get_initial_value()
-        model_parameters["a"].heuristic = fit.values["y0"] * sgn * 2 / fwhmh
+        self.parameters["fwhmh"].heuristic = 1 / fit.values["tau"]
+        fwhmh = self.parameters["fwhmh"].get_initial_value()
+        self.parameters["a"].heuristic = fit.values["y0"] * sgn * 2 / fwhmh
 
         cut_off = 2 * fit.values["tau"]
 
         x0 = self.find_x_offset_sym_peak(
             x=x,
             y=y,
-            parameters=model_parameters,
+            parameters=self.parameters,
             omega=omega,
             spectrum=spectrum,
             omega_cut_off=cut_off,
             test_pts=x[peak_idx],
         )
 
-        model_parameters["x0"].heuristic = x0
+        self.parameters["x0"].heuristic = x0

--- a/ionics_fits/models/molmer_sorensen.py
+++ b/ionics_fits/models/molmer_sorensen.py
@@ -2,9 +2,9 @@ from typing import Dict, Tuple, TYPE_CHECKING
 
 import numpy as np
 
+from . import heuristics
 from .. import common, Model, ModelParameter
 from ..utils import Array
-from . import heuristics
 
 
 if TYPE_CHECKING:
@@ -257,10 +257,10 @@ class MolmerSorensenTime(MolmerSorensen):
 
         if not self.parameters["omega"].has_user_initial_value():
             omegas = np.array([np.linspace(0.1, 10, 25)]) * np.pi / max(x)
-            self.parameters["omega"].heuristic, _ = self.param_min_sqrs(
+            self.parameters["omega"].heuristic, _ = heuristics.param_min_sqrs(
+                model=self,
                 x=x,
                 y=y,
-                parameters=self.parameters,
                 scanned_param="omega",
                 scanned_param_values=omegas,
             )
@@ -268,10 +268,10 @@ class MolmerSorensenTime(MolmerSorensen):
         elif not self.parameters["delta"].has_user_initial_value():
             omega = self.parameters["omega"].get_initial_value()
             deltas = np.array([np.linspace(0, 10, 25)]) * omega
-            self.parameters["delta"].heuristic, _ = self.param_min_sqrs(
+            self.parameters["delta"].heuristic, _ = heuristics.param_min_sqrs(
+                model=self,
                 x=x,
                 y=y,
-                parameters=self.parameters,
                 scanned_param="delta",
                 scanned_param_values=deltas,
             )
@@ -338,10 +338,10 @@ class MolmerSorensenFreq(MolmerSorensen):
                 # the centre frequency is close to the edge of the scan range.
                 # Since w_0 is our only unknown here, we throw in a sampling
                 # heuristic for good measure.
-                w_0_grid, w_0_grid_cost = self.param_min_sqrs(
+                w_0_grid, w_0_grid_cost = heuristics.param_min_sqrs(
+                    model=self,
                     x=x,
                     y=y,
-                    parameters=self.parameters,
                     scanned_param="w_0",
                     scanned_param_values=np.linspace(min(x), max(x), 50),
                 )
@@ -357,10 +357,10 @@ class MolmerSorensenFreq(MolmerSorensen):
 
         if self.parameters["t_pulse"].has_user_initial_value():
             t_pulse = self.parameters["t_pulse"].get_initial_value()
-            self.parameters["omega"].heuristic, _ = self.param_min_sqrs(
+            self.parameters["omega"].heuristic, _ = heuristics.param_min_sqrs(
+                model=self,
                 x=x,
                 y=y,
-                parameters=self.parameters,
                 scanned_param="omega",
                 scanned_param_values=np.array([np.linspace(0.25, 5, 10)])
                 * np.pi
@@ -368,10 +368,10 @@ class MolmerSorensenFreq(MolmerSorensen):
             )
         elif self.parameters["omega"].has_user_initial_value():
             omega = self.parameters["omega"].get_initial_value()
-            self.parameters["t_pulse"].heuristic, _ = self.param_min_sqrs(
+            self.parameters["t_pulse"].heuristic, _ = heuristics.param_min_sqrs(
+                model=self,
                 x=x,
                 y=y,
-                parameters=self.parameters,
                 scanned_param="t_pulse",
                 scanned_param_values=np.array([np.linspace(0.25, 5, 10)])
                 * np.pi
@@ -386,10 +386,10 @@ class MolmerSorensenFreq(MolmerSorensen):
             t_pulses = np.zeros_like(omegas)
             for idx, omega in np.ndenumerate(omegas):
                 self.parameters["omega"].heuristic = omega
-                t_pulses[idx], costs[idx] = self.param_min_sqrs(
+                t_pulses[idx], costs[idx] = heuristics.param_min_sqrs(
+                    model=self,
                     x=x,
                     y=y,
-                    parameters=self.parameters,
                     scanned_param="t_pulse",
                     scanned_param_values=np.array([np.linspace(0.1, 5, 20)])
                     * np.pi

--- a/ionics_fits/models/molmer_sorensen.py
+++ b/ionics_fits/models/molmer_sorensen.py
@@ -76,9 +76,8 @@ class MolmerSorensen(Model):
     def get_num_y_channels(self) -> int:
         return [1, 3][self.num_qubits - 1]
 
-    def can_rescale(self, x_scale: float, y_scale: float) -> bool:
-        # return True
-        return False  # https://github.com/OxIonics/ionics_fits/issues/105
+    def can_rescale(self) -> Tuple[bool, bool]:
+        return True, False
 
     # pytype: disable=invalid-annotation
     def _func(

--- a/ionics_fits/models/molmer_sorensen.py
+++ b/ionics_fits/models/molmer_sorensen.py
@@ -246,36 +246,35 @@ class MolmerSorensenTime(MolmerSorensen):
         self,
         x: Array[("num_samples",), np.float64],
         y: Array[("num_y_channels", "num_samples"), np.float64],
-        model_parameters: Dict[str, ModelParameter],
     ):
-        model_parameters["n_bar"].heuristic = 0.0
+        self.parameters["n_bar"].heuristic = 0.0
         if (
-            not model_parameters["delta"].has_user_initial_value()
-            and not model_parameters["omega"].has_user_initial_value()
+            not self.parameters["delta"].has_user_initial_value()
+            and not self.parameters["omega"].has_user_initial_value()
         ):
             # This case is pretty miserable because there is a very high degree
             # of covariance between delta and omega so even if the heuristics are
             # highly accurate, the optimizer will tend to struggle to converge on
             # the right parameter values.
-            model_parameters["delta"].heuristic = 0.0
+            self.parameters["delta"].heuristic = 0.0
 
-        if not model_parameters["omega"].has_user_initial_value():
+        if not self.parameters["omega"].has_user_initial_value():
             omegas = np.array([np.linspace(0.1, 10, 25)]) * np.pi / max(x)
-            model_parameters["omega"].heuristic, _ = self.param_min_sqrs(
+            self.parameters["omega"].heuristic, _ = self.param_min_sqrs(
                 x=x,
                 y=y,
-                parameters=model_parameters,
+                parameters=self.parameters,
                 scanned_param="omega",
                 scanned_param_values=omegas,
             )
 
-        elif not model_parameters["delta"].has_user_initial_value():
-            omega = model_parameters["omega"].get_initial_value()
+        elif not self.parameters["delta"].has_user_initial_value():
+            omega = self.parameters["omega"].get_initial_value()
             deltas = np.array([np.linspace(0, 10, 25)]) * omega
-            model_parameters["delta"].heuristic, _ = self.param_min_sqrs(
+            self.parameters["delta"].heuristic, _ = self.param_min_sqrs(
                 x=x,
                 y=y,
-                parameters=model_parameters,
+                parameters=self.parameters,
                 scanned_param="delta",
                 scanned_param_values=deltas,
             )
@@ -331,20 +330,19 @@ class MolmerSorensenFreq(MolmerSorensen):
         self,
         x: Array[("num_samples",), np.float64],
         y: Array[("num_y_channels", "num_samples"), np.float64],
-        model_parameters: Dict[str, ModelParameter],
     ):
-        model_parameters["n_bar"].heuristic = 0.0
+        self.parameters["n_bar"].heuristic = 0.0
 
         # estimate the centre frequency by looking for the symmetry point.
         # Consider only the 1-ion transition probability
         y_test = y if self.num_qubits == 1 else np.atleast_2d(y[1, :])
-        w_0 = model_parameters["w_0"].heuristic = heuristics.get_sym_x(x, y_test)
+        w_0 = self.parameters["w_0"].heuristic = heuristics.get_sym_x(x, y_test)
 
         if (
-            model_parameters["t_pulse"].has_user_initial_value()
-            and model_parameters["omega"].has_user_initial_value()
+            self.parameters["t_pulse"].has_user_initial_value()
+            and self.parameters["omega"].has_user_initial_value()
         ):
-            if not model_parameters["w_0"].has_user_initial_value():
+            if not self.parameters["w_0"].has_user_initial_value():
                 # The symmetry heuristic is pretty good, but can struggle when
                 # the centre frequency is close to the edge of the scan range.
                 # Since w_0 is our only unknown here, we throw in a sampling
@@ -352,37 +350,37 @@ class MolmerSorensenFreq(MolmerSorensen):
                 w_0_grid, w_0_grid_cost = self.param_min_sqrs(
                     x=x,
                     y=y,
-                    parameters=model_parameters,
+                    parameters=self.parameters,
                     scanned_param="w_0",
                     scanned_param_values=np.linspace(min(x), max(x), 50),
                 )
                 param_values = {
                     name: param.get_initial_value()
-                    for name, param in model_parameters.items()
+                    for name, param in self.parameters.items()
                 }
                 y_sym = self.func(x, param_values)
                 w_0_sym_cost = np.sqrt(np.sum(np.square(y - y_sym)))
                 w_0 = w_0 if w_0_sym_cost < w_0_grid_cost else w_0_grid
-                model_parameters["w_0"].heuristic = w_0
+                self.parameters["w_0"].heuristic = w_0
             return
 
-        if model_parameters["t_pulse"].has_user_initial_value():
-            t_pulse = model_parameters["t_pulse"].get_initial_value()
-            model_parameters["omega"].heuristic, _ = self.param_min_sqrs(
+        if self.parameters["t_pulse"].has_user_initial_value():
+            t_pulse = self.parameters["t_pulse"].get_initial_value()
+            self.parameters["omega"].heuristic, _ = self.param_min_sqrs(
                 x=x,
                 y=y,
-                parameters=model_parameters,
+                parameters=self.parameters,
                 scanned_param="omega",
                 scanned_param_values=np.array([np.linspace(0.25, 5, 10)])
                 * np.pi
                 / t_pulse,
             )
-        elif model_parameters["omega"].has_user_initial_value():
-            omega = model_parameters["omega"].get_initial_value()
-            model_parameters["t_pulse"].heuristic, _ = self.param_min_sqrs(
+        elif self.parameters["omega"].has_user_initial_value():
+            omega = self.parameters["omega"].get_initial_value()
+            self.parameters["t_pulse"].heuristic, _ = self.param_min_sqrs(
                 x=x,
                 y=y,
-                parameters=model_parameters,
+                parameters=self.parameters,
                 scanned_param="t_pulse",
                 scanned_param_values=np.array([np.linspace(0.25, 5, 10)])
                 * np.pi
@@ -396,19 +394,19 @@ class MolmerSorensenFreq(MolmerSorensen):
             costs = np.zeros_like(omegas)
             t_pulses = np.zeros_like(omegas)
             for idx, omega in np.ndenumerate(omegas):
-                model_parameters["omega"].heuristic = omega
+                self.parameters["omega"].heuristic = omega
                 t_pulses[idx], costs[idx] = self.param_min_sqrs(
                     x=x,
                     y=y,
-                    parameters=model_parameters,
+                    parameters=self.parameters,
                     scanned_param="t_pulse",
                     scanned_param_values=np.array([np.linspace(0.1, 5, 20)])
                     * np.pi
                     / omega,
                 )
             best = np.argmin(costs)
-            model_parameters["omega"].heuristic = omegas[best]
-            model_parameters["t_pulse"].heuristic = t_pulses[best]
+            self.parameters["omega"].heuristic = omegas[best]
+            self.parameters["t_pulse"].heuristic = t_pulses[best]
 
     def calculate_derived_params(
         self,

--- a/ionics_fits/models/polynomial.py
+++ b/ionics_fits/models/polynomial.py
@@ -2,6 +2,7 @@ from typing import Dict, Tuple, TYPE_CHECKING
 
 import numpy as np
 
+from . import heuristics
 from .containers import MappedModel
 from .. import common, Model, ModelParameter
 from ..utils import Array
@@ -101,7 +102,9 @@ class Power(Model):
             x = x - x0
             y = y - y0
             a = y / np.float_power(x, n)
-            a = self.param_min_sqrs(x, y, self.parameters, "a", a)[0]
+            a = heuristics.param_min_sqrs(
+                model=self, x=x, y=y, scanned_param="a", scanned_param_values=a
+            )[0]
             self.parameters["a"].heuristic = a
 
         elif unknowns == {"n"}:
@@ -110,7 +113,9 @@ class Power(Model):
 
         elif unknowns == {"y0"}:
             y0 = y - a * np.float_power(x - x0, n)
-            y0 = self.param_min_sqrs(x, y, self.parameters, "y0", y0)[0]
+            y0 = heuristics.param_min_sqrs(
+                model=self, x=x, y=y, scanned_param="y0", scanned_param_values=y0
+            )[0]
             self.parameters["y0"].heuristic = y0
 
         elif "a" in unknowns:
@@ -181,7 +186,7 @@ class Power(Model):
         if len(n) == 0:
             return 1, np.inf
 
-        return self.param_min_sqrs(x, y, self.parameters, "n", n)
+        return heuristics.param_min_sqrs(self, x, y, "n", n)
 
 
 def poly_fit_parameter(n):

--- a/ionics_fits/models/polynomial.py
+++ b/ionics_fits/models/polynomial.py
@@ -1,4 +1,4 @@
-from typing import Dict, TYPE_CHECKING
+from typing import Dict, Tuple, TYPE_CHECKING
 
 import numpy as np
 
@@ -39,13 +39,16 @@ class Power(Model):
     def get_num_y_channels(self) -> int:
         return 1
 
-    def can_rescale(self, x_scale: float, y_scale: float) -> bool:
-        return False if self.parameters["n"].fixed_to is None else True
+    def can_rescale(self) -> Tuple[bool, bool]:
+        rescale_x = False if self.parameters["n"].fixed_to is None else True
+        return rescale_x, True
 
     @staticmethod
     def get_scaled_model(model, x_scale: float, y_scale: float):
         def scale_func(x_scale, y_scale) -> float:
             # NB the common scale functions do not support float powers
+            if x_scale == 1.0:
+                return y_scale
             return y_scale / np.float_power(x_scale, model.parameters["n"].fixed_to)
 
         model.parameters["a"].scale_func = scale_func
@@ -222,8 +225,9 @@ class Polynomial(Model):
     def get_num_y_channels(self) -> int:
         return 1
 
-    def can_rescale(self, x_scale: float, y_scale: float) -> bool:
-        return True if self.parameters["x0"].fixed_to == 0.0 else False
+    def can_rescale(self) -> Tuple[bool, bool]:
+        rescale_x = True if self.parameters["x0"].fixed_to == 0.0 else False
+        return rescale_x, True
 
     def func(
         self, x: Array[("num_samples",), np.float64], params: Dict[str, float]

--- a/ionics_fits/models/polynomial.py
+++ b/ionics_fits/models/polynomial.py
@@ -43,16 +43,15 @@ class Power(Model):
         rescale_x = False if self.parameters["n"].fixed_to is None else True
         return rescale_x, True
 
-    @staticmethod
-    def get_scaled_model(model, x_scale: float, y_scale: float):
+    def rescale(self, x_scale: float, y_scale: float):
         def scale_func(x_scale, y_scale) -> float:
             # NB the common scale functions do not support float powers
             if x_scale == 1.0:
                 return y_scale
-            return y_scale / np.float_power(x_scale, model.parameters["n"].fixed_to)
+            return y_scale / np.float_power(x_scale, self.parameters["n"].fixed_to)
 
-        model.parameters["a"].scale_func = scale_func
-        return super().get_scaled_model(model=model, x_scale=x_scale, y_scale=y_scale)
+        self.parameters["a"].scale_func = scale_func
+        super().rescale(x_scale=x_scale, y_scale=y_scale)
 
     # pytype: disable=invalid-annotation
     def _func(

--- a/ionics_fits/models/quantum_phys.py
+++ b/ionics_fits/models/quantum_phys.py
@@ -2,6 +2,7 @@ import numpy as np
 from scipy import special
 from typing import TYPE_CHECKING
 
+from .. import common
 from ..common import Array, ModelParameter
 
 
@@ -11,7 +12,7 @@ if TYPE_CHECKING:
 
 # pytype: disable=invalid-annotation
 def thermal_state_probs(
-    n_max: int, n_bar: ModelParameter(lower_bound=0)
+    n_max: int, n_bar: ModelParameter(lower_bound=0, scale_func=common.scale_invariant)
 ) -> Array[("num_fock_states",), np.float64]:
     """Returns an array of Fock state occupation probabilities for a thermal state of
     mean occupancy :param n_bar:, truncated at a maximum Fock state of |n_max>
@@ -24,7 +25,7 @@ def thermal_state_probs(
 
 # pytype: disable=invalid-annotation
 def coherent_state_probs(
-    n_max: int, alpha: ModelParameter(lower_bound=0)
+    n_max: int, alpha: ModelParameter(lower_bound=0, scale_func=common.scale_invariant)
 ) -> Array[("num_fock_states",), np.float64]:
     """Returns an array of the Fock state occupation probabilities for a coherent
     state described by :param alpha:, truncated at a maximum Fock state of |n_max>.
@@ -55,7 +56,7 @@ def coherent_state_probs(
 
 # pytype: disable=invalid-annotation
 def squeezed_state_probs(
-    n_max: int, zeta: ModelParameter(lower_bound=0)
+    n_max: int, zeta: ModelParameter(lower_bound=0, scale_func=common.scale_invariant)
 ) -> Array[("num_fock_states",), np.float64]:
     """
     Return occupation probabilities of Fock states for pure squeezed state.

--- a/ionics_fits/models/quantum_phys.py
+++ b/ionics_fits/models/quantum_phys.py
@@ -18,7 +18,7 @@ def thermal_state_probs(
     mean occupancy :param n_bar:, truncated at a maximum Fock state of |n_max>
     """
     n = np.arange(n_max + 1, dtype=int)
-    return np.power(n_bar / (n_bar + 1), n) / (n_bar + 1)
+    return ((n_bar / (n_bar + 1)) ** n) / (n_bar + 1)
 
 
 # pytype: enable=invalid-annotation
@@ -38,7 +38,7 @@ def coherent_state_probs(
     :param alpha: Complex displacement parameter
     """
     n = np.arange(n_max + 1, dtype=int)
-    n_bar = np.power(np.abs(alpha), 2)
+    n_bar = np.abs(alpha) ** 2
 
     # The standard expression is: P_n = n_bar**n * exp(-n_bar) / n!
     # However, this is difficult to evaluate as n increases, so we use an alternate form
@@ -78,7 +78,7 @@ def squeezed_state_probs(
         P_n[0] = 1
     else:
         P_n = (
-            np.power(np.tanh(r), 2 * n)
+            (np.tanh(r) ** (2 * n))
             / np.cosh(r)
             * np.exp(
                 special.gammaln(2 * n + 1)

--- a/ionics_fits/models/rabi.py
+++ b/ionics_fits/models/rabi.py
@@ -324,7 +324,7 @@ class RabiFlopTime(RabiFlop):
         else:
             # can't use param_min_sqrs because omega and delta are coupled
             deltas = np.linspace(0, W / 2, 10)
-            omegas = np.sqrt(W**2 - np.power(deltas, 2))
+            omegas = np.sqrt(W**2 - deltas**2)
             costs = np.zeros_like(deltas)
 
             initial_values = {
@@ -337,7 +337,7 @@ class RabiFlopTime(RabiFlop):
                 initial_values["delta"] = deltas[idx]
                 initial_values["omega"] = omegas[idx]
                 y_idx = self.func(x, initial_values)
-                costs[idx] = np.sqrt(np.sum(np.power(y - y_idx, 2)))
+                costs[idx] = np.sqrt(np.sum((y - y_idx) ** 2))
             opt_idx = np.argmin(costs)
 
             self.parameters["delta"].heuristic = deltas[opt_idx]

--- a/ionics_fits/models/rabi.py
+++ b/ionics_fits/models/rabi.py
@@ -66,8 +66,8 @@ class RabiFlop(Model):
     def get_num_y_channels(self) -> int:
         return 1
 
-    def can_rescale(self, x_scale: float, y_scale: float) -> bool:
-        return True
+    def can_rescale(self) -> Tuple[bool, bool]:
+        return True, True
 
     # pytype: disable=invalid-annotation
     def _func(

--- a/ionics_fits/models/rabi.py
+++ b/ionics_fits/models/rabi.py
@@ -2,6 +2,7 @@ from typing import Dict, Tuple, TYPE_CHECKING
 
 import numpy as np
 
+from . import heuristics
 from .sinc import Sinc2
 from .sinusoid import Sinusoid
 from .. import common, Model, ModelParameter, NormalFitter
@@ -203,10 +204,10 @@ class RabiFlopFreq(RabiFlop):
 
         if unknowns == {"w_0"}:
             omega, spectrum = get_spectrum(x, y, trim_dc=True)
-            w_0 = self.find_x_offset_sym_peak(
+            w_0 = heuristics.find_x_offset_sym_peak(
+                model=self,
                 x=x,
                 y=y,
-                parameters=self.parameters,
                 omega=omega,
                 spectrum=spectrum,
                 omega_cut_off=self.parameters["t_pulse"].get_initial_value(),
@@ -245,8 +246,8 @@ class RabiFlopFreq(RabiFlop):
         # sufficiently high contrast for the y-axis rescaling to not do much!
         x_sample = x[np.argwhere(np.abs(y - y0) > 0.3)]
         x_trial = np.append(x_sample, [x_sinc])
-        w_0, _ = self.param_min_sqrs(
-            x, y, self.parameters, scanned_param="w_0", scanned_param_values=x_trial
+        w_0, _ = heuristics.param_min_sqrs(
+            model=self, x=x, y=y, scanned_param="w_0", scanned_param_values=x_trial
         )
         self.parameters["w_0"].heuristic = w_0
 
@@ -362,10 +363,10 @@ class RabiFlopTime(RabiFlop):
             omega_max = np.pi * n_pi_max / min(x)
             omegas = np.linspace(omega_min, omega_max, num_pts)
 
-            self.parameters["omega"].heuristic, _ = self.param_min_sqrs(
+            self.parameters["omega"].heuristic, _ = heuristics.param_min_sqrs(
+                model=self,
                 x=x,
                 y=y,
-                parameters=self.parameters,
                 scanned_param="omega",
                 scanned_param_values=omegas,
             )

--- a/ionics_fits/models/rectangle.py
+++ b/ionics_fits/models/rectangle.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING
 import numpy as np
 
-from .. import Model, ModelParameter
+from .. import common, Model, ModelParameter
 from ..utils import Array
 
 if TYPE_CHECKING:
@@ -32,17 +32,19 @@ class Rectangle(Model):
         super().__init__()
 
     def get_num_y_channels(self) -> int:
-        """Returns the number of y channels supported by the model"""
         return 1
+
+    def can_rescale(self, x_scale: float, y_scale: float) -> bool:
+        return True
 
     # pytype: disable=invalid-annotation
     def _func(
         self,
         x: Array[("num_samples",), np.float64],
-        a: ModelParameter(scale_func=lambda x_scale, y_scale, _: y_scale),
-        y0: ModelParameter(scale_func=lambda x_scale, y_scale, _: y_scale),
-        x_l: ModelParameter(scale_func=lambda x_scale, y_scale, _: x_scale),
-        x_r: ModelParameter(scale_func=lambda x_scale, y_scale, _: x_scale),
+        a: ModelParameter(scale_func=common.scale_y),
+        y0: ModelParameter(scale_func=common.scale_y),
+        x_l: ModelParameter(scale_func=common.scale_x),
+        x_r: ModelParameter(scale_func=common.scale_x),
     ) -> Array[("num_samples",), np.float64]:
         return np.where(np.logical_and(x_r > x, x > x_l), y0 + a, y0)
 

--- a/ionics_fits/models/rectangle.py
+++ b/ionics_fits/models/rectangle.py
@@ -1,4 +1,4 @@
-from typing import Dict, TYPE_CHECKING
+from typing import TYPE_CHECKING
 import numpy as np
 
 from .. import Model, ModelParameter
@@ -52,65 +52,49 @@ class Rectangle(Model):
         self,
         x: Array[("num_samples",), np.float64],
         y: Array[("num_samples",), np.float64],
-        model_parameters: Dict[str, ModelParameter],
     ):
-        """Set heuristic values for model parameters.
-
-        Typically called during `Fitter.fit`. This method may make use of information
-        supplied by the user for some parameters (via the `fixed_to` or
-        `user_estimate` attributes) to find initial guesses for other parameters.
-
-        The datasets must be sorted in order of increasing x-axis values and must not
-        contain any infinite or nan values. If all parameters of the model allow
-        rescaling, then `x`, `y` and `model_parameters` will contain rescaled values.
-
-        :param x: x-axis data, rescaled if allowed.
-        :param y: y-axis data, rescaled if allowed.
-        :param model_parameters: dictionary mapping model parameter names to their
-            metadata, rescaled if allowed.
-        """
         # Ensure that y is a 1D array
         y = np.squeeze(y)
 
         unknowns = {
             param
-            for param, param_data in model_parameters.items()
+            for param, param_data in self.parameters.items()
             if not param_data.has_user_initial_value()
         }
 
         if {"x_l", "x_r"}.issubset(unknowns):
-            model_parameters["y0"].heuristic = 0.5 * (y[0] + y[-1])
+            self.parameters["y0"].heuristic = 0.5 * (y[0] + y[-1])
 
         elif "x_l" not in unknowns:
-            x_l = model_parameters["x_l"].get_initial_value()
+            x_l = self.parameters["x_l"].get_initial_value()
 
             if min(x) < x_l:
-                model_parameters["y0"].heuristic = np.mean(y[x < x_l])
+                self.parameters["y0"].heuristic = np.mean(y[x < x_l])
             else:
-                y0 = model_parameters["y0"].heuristic = y[-1]
-                model_parameters["a"].heuristic = y[0] - y0
+                y0 = self.parameters["y0"].heuristic = y[-1]
+                self.parameters["a"].heuristic = y[0] - y0
 
         elif "x_r" not in unknowns:
-            x_r = model_parameters["x_r"].get_initial_value()
+            x_r = self.parameters["x_r"].get_initial_value()
             if max(x) > x_r:
-                model_parameters["y0"].heuristic = np.mean(y[x > x_r])
+                self.parameters["y0"].heuristic = np.mean(y[x > x_r])
             else:
-                y0 = model_parameters["y0"].heuristic = y[0]
-                model_parameters["a"].heuristic = y[-1] - y0
+                y0 = self.parameters["y0"].heuristic = y[0]
+                self.parameters["a"].heuristic = y[-1] - y0
 
         else:
-            x_l = model_parameters["x_l"].get_initial_value()
-            x_r = model_parameters["x_r"].get_initial_value()
+            x_l = self.parameters["x_l"].get_initial_value()
+            x_r = self.parameters["x_r"].get_initial_value()
 
             outside = np.logical_or(x <= x_l, x >= x_r)
             inside = np.logical_and(x > x_l, x < x_r)
-            model_parameters["y0"].heuristic = np.mean(y[outside])
-            y0 = model_parameters["y0"].get_initial_value()
-            model_parameters["a"].heuristic = np.mean(y[outside] - y0)
+            self.parameters["y0"].heuristic = np.mean(y[outside])
+            y0 = self.parameters["y0"].get_initial_value()
+            self.parameters["a"].heuristic = np.mean(y[outside] - y0)
 
-        y0 = model_parameters["y0"].get_initial_value()
-        model_parameters["a"].heuristic = y[np.argmax(np.abs(y - y0))] - y0
-        a = model_parameters["a"].get_initial_value()
+        y0 = self.parameters["y0"].get_initial_value()
+        self.parameters["a"].heuristic = y[np.argmax(np.abs(y - y0))] - y0
+        a = self.parameters["a"].get_initial_value()
 
         thresh = self.thresh * (y0 + (y0 + a))
         inside = (y >= thresh) if a > 0 else (y < thresh)
@@ -122,5 +106,5 @@ class Rectangle(Model):
             x_l = min(x[inside])
             x_r = max(x[inside])
 
-        model_parameters["x_l"].heuristic = x_l
-        model_parameters["x_r"].heuristic = x_r
+        self.parameters["x_l"].heuristic = x_l
+        self.parameters["x_r"].heuristic = x_r

--- a/ionics_fits/models/rectangle.py
+++ b/ionics_fits/models/rectangle.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import Tuple, TYPE_CHECKING
 import numpy as np
 
 from .. import common, Model, ModelParameter
@@ -34,8 +34,8 @@ class Rectangle(Model):
     def get_num_y_channels(self) -> int:
         return 1
 
-    def can_rescale(self, x_scale: float, y_scale: float) -> bool:
-        return True
+    def can_rescale(self) -> Tuple[bool, bool]:
+        return True, True
 
     # pytype: disable=invalid-annotation
     def _func(

--- a/ionics_fits/models/sinc.py
+++ b/ionics_fits/models/sinc.py
@@ -4,7 +4,7 @@ import numpy as np
 from .rectangle import Rectangle
 from .triangle import Triangle
 from .utils import get_spectrum
-from .. import NormalFitter, Model, ModelParameter
+from .. import common, NormalFitter, Model, ModelParameter
 from ..utils import Array
 
 if TYPE_CHECKING:
@@ -26,19 +26,19 @@ class Sinc(Model):
     """
 
     def get_num_y_channels(self) -> int:
-        """Returns the number of y channels supported by the model"""
         return 1
+
+    def can_rescale(self, x_scale: float, y_scale: float) -> bool:
+        return True
 
     # pytype: disable=invalid-annotation
     def _func(
         self,
         x: Array[("num_samples",), np.float64],
-        x0: ModelParameter(scale_func=lambda x_scale, y_scale, _: x_scale),
-        y0: ModelParameter(scale_func=lambda x_scale, y_scale, _: y_scale),
-        a: ModelParameter(scale_func=lambda x_scale, y_scale, _: y_scale),
-        w: ModelParameter(
-            lower_bound=0, scale_func=lambda x_scale, y_scale, _: 1 / x_scale
-        ),
+        x0: ModelParameter(scale_func=common.scale_x),
+        y0: ModelParameter(scale_func=common.scale_y),
+        a: ModelParameter(scale_func=common.scale_y),
+        w: ModelParameter(lower_bound=0, scale_func=common.scale_x_inv),
     ) -> Array[("num_samples",), np.float64]:
         x = w * (x - x0) / np.pi  # np.sinc(x) = sin(pi*x) / (pi*x)
         y = a * np.sinc(x) + y0
@@ -100,19 +100,19 @@ class Sinc2(Model):
     """
 
     def get_num_y_channels(self) -> int:
-        """Returns the number of y channels supported by the model"""
         return 1
+
+    def can_rescale(self, x_scale: float, y_scale: float) -> bool:
+        return True
 
     # pytype: disable=invalid-annotation
     def _func(
         self,
         x: Array[("num_samples",), np.float64],
-        x0: ModelParameter(scale_func=lambda x_scale, y_scale, _: x_scale),
-        y0: ModelParameter(scale_func=lambda x_scale, y_scale, _: y_scale),
-        a: ModelParameter(scale_func=lambda x_scale, y_scale, _: y_scale),
-        w: ModelParameter(
-            lower_bound=0, scale_func=lambda x_scale, y_scale, _: 1 / x_scale
-        ),
+        x0: ModelParameter(scale_func=common.scale_x),
+        y0: ModelParameter(scale_func=common.scale_y),
+        a: ModelParameter(scale_func=common.scale_y),
+        w: ModelParameter(lower_bound=0, scale_func=common.scale_x_inv),
     ) -> Array[("num_samples",), np.float64]:
         x = w * (x - x0) / np.pi  # np.sinc(x) = sin(pi*x) / (pi*x)
         y = a * np.power(np.sinc(x), 2) + y0

--- a/ionics_fits/models/sinc.py
+++ b/ionics_fits/models/sinc.py
@@ -1,4 +1,4 @@
-from typing import Dict, TYPE_CHECKING
+from typing import TYPE_CHECKING
 import numpy as np
 
 from .rectangle import Rectangle
@@ -49,28 +49,12 @@ class Sinc(Model):
         self,
         x: Array[("num_samples",), np.float64],
         y: Array[("num_samples",), np.float64],
-        model_parameters: Dict[str, ModelParameter],
     ):
-        """Sets initial values for model parameters based on heuristics. Typically
-        called during `Fitter.fit`.
-
-        Heuristic results should be stored in :param model_parameters: using the
-        `ModelParameter`'s `heuristic` attribute. This ensures that all information
-        passed in by the user (fixed values, initial values, bounds) is used correctly.
-
-        The dataset must be sorted in order of increasing x-axis values and must not
-        contain any infinite or nan values.
-
-        :param x: x-axis data
-        :param y: y-axis data
-        :param model_parameters: dictionary mapping model parameter names to their
-            metadata.
-        """
         # Ensure that y is a 1D array
         y = np.squeeze(y)
 
-        model_parameters["y0"].heuristic = np.mean([y[0], y[-1]])
-        y0 = model_parameters["y0"].get_initial_value()
+        self.parameters["y0"].heuristic = np.mean([y[0], y[-1]])
+        y0 = self.parameters["y0"].get_initial_value()
 
         omega, spectrum = get_spectrum(x, y, trim_dc=True)
         abs_spectrum = np.abs(spectrum)
@@ -83,22 +67,22 @@ class Sinc(Model):
 
         fit = NormalFitter(omega, abs_spectrum, model=rect)
 
-        model_parameters["w"].heuristic = fit.values["x_r"]
-        w = model_parameters["w"].get_initial_value()
+        self.parameters["w"].heuristic = fit.values["x_r"]
+        w = self.parameters["w"].get_initial_value()
 
         sgn = 1 if y[np.argmax(np.abs(y - y0))] > y0 else -1
-        model_parameters["a"].heuristic = 2 * w * fit.values["a"] * sgn
+        self.parameters["a"].heuristic = 2 * w * fit.values["a"] * sgn
 
         x0 = self.find_x_offset_sym_peak(
             x=x,
             y=y,
-            parameters=model_parameters,
+            parameters=self.parameters,
             omega=omega,
             spectrum=spectrum,
             omega_cut_off=w,
         )
 
-        model_parameters["x0"].heuristic = x0
+        self.parameters["x0"].heuristic = x0
 
 
 class Sinc2(Model):
@@ -140,27 +124,11 @@ class Sinc2(Model):
         self,
         x: Array[("num_samples",), np.float64],
         y: Array[("num_samples",), np.float64],
-        model_parameters: Dict[str, ModelParameter],
     ):
-        """Sets initial values for model parameters based on heuristics. Typically
-        called during `Fitter.fit`.
-
-        Heuristic results should stored in :param model_parameters: using the
-        `ModelParameter`'s `initialise` method. This ensures that all information passed
-        in by the user (fixed values, initial values, bounds) is used correctly.
-
-        The dataset must be sorted in order of increasing x-axis values and must not
-        contain any infinite or nan values.
-
-        :param x: x-axis data
-        :param y: y-axis data
-        :param model_parameters: dictionary mapping model parameter names to their
-            metadata.
-        """
         # Ensure that y is a 1D array
         y = np.squeeze(y)
 
-        y0 = model_parameters["y0"].heuristic = np.mean([y[0], y[-1]])
+        y0 = self.parameters["y0"].heuristic = np.mean([y[0], y[-1]])
 
         omega, spectrum = get_spectrum(x, y, trim_dc=True)
         abs_spectrum = np.abs(spectrum)
@@ -177,16 +145,16 @@ class Sinc2(Model):
         intercept = fit.values["y0"] / -fit.values["k"]
         sgn = 1 if y[np.argmax(np.abs(y - y0))] > y0 else -1
 
-        model_parameters["w"].heuristic = 0.5 * intercept
-        model_parameters["a"].heuristic = fit.values["y0"] * sgn * intercept
+        self.parameters["w"].heuristic = 0.5 * intercept
+        self.parameters["a"].heuristic = fit.values["y0"] * sgn * intercept
 
         x0 = self.find_x_offset_sym_peak(
             x=x,
             y=y,
-            parameters=model_parameters,
+            parameters=self.parameters,
             omega=omega,
             spectrum=spectrum,
             omega_cut_off=intercept,
         )
 
-        model_parameters["x0"].heuristic = x0
+        self.parameters["x0"].heuristic = x0

--- a/ionics_fits/models/sinc.py
+++ b/ionics_fits/models/sinc.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import Tuple, TYPE_CHECKING
 import numpy as np
 
 from .rectangle import Rectangle
@@ -28,8 +28,8 @@ class Sinc(Model):
     def get_num_y_channels(self) -> int:
         return 1
 
-    def can_rescale(self, x_scale: float, y_scale: float) -> bool:
-        return True
+    def can_rescale(self) -> Tuple[bool, bool]:
+        return True, True
 
     # pytype: disable=invalid-annotation
     def _func(
@@ -102,8 +102,8 @@ class Sinc2(Model):
     def get_num_y_channels(self) -> int:
         return 1
 
-    def can_rescale(self, x_scale: float, y_scale: float) -> bool:
-        return True
+    def can_rescale(self) -> Tuple[bool, bool]:
+        return True, True
 
     # pytype: disable=invalid-annotation
     def _func(

--- a/ionics_fits/models/sinc.py
+++ b/ionics_fits/models/sinc.py
@@ -1,10 +1,11 @@
 from typing import Tuple, TYPE_CHECKING
 import numpy as np
 
+from . import heuristics
 from .rectangle import Rectangle
 from .triangle import Triangle
 from .utils import get_spectrum
-from .. import common, NormalFitter, Model, ModelParameter
+from .. import common, Model, ModelParameter, NormalFitter
 from ..utils import Array
 
 if TYPE_CHECKING:
@@ -73,10 +74,10 @@ class Sinc(Model):
         sgn = 1 if y[np.argmax(np.abs(y - y0))] > y0 else -1
         self.parameters["a"].heuristic = 2 * w * fit.values["a"] * sgn
 
-        x0 = self.find_x_offset_sym_peak(
+        x0 = heuristics.find_x_offset_sym_peak(
+            model=self,
             x=x,
             y=y,
-            parameters=self.parameters,
             omega=omega,
             spectrum=spectrum,
             omega_cut_off=w,
@@ -148,10 +149,10 @@ class Sinc2(Model):
         self.parameters["w"].heuristic = 0.5 * intercept
         self.parameters["a"].heuristic = fit.values["y0"] * sgn * intercept
 
-        x0 = self.find_x_offset_sym_peak(
+        x0 = heuristics.find_x_offset_sym_peak(
+            model=self,
             x=x,
             y=y,
-            parameters=self.parameters,
             omega=omega,
             spectrum=spectrum,
             omega_cut_off=intercept,

--- a/ionics_fits/models/sinc.py
+++ b/ionics_fits/models/sinc.py
@@ -116,7 +116,7 @@ class Sinc2(Model):
         w: ModelParameter(lower_bound=0, scale_func=common.scale_x_inv),
     ) -> Array[("num_samples",), np.float64]:
         x = w * (x - x0) / np.pi  # np.sinc(x) = sin(pi*x) / (pi*x)
-        y = a * np.power(np.sinc(x), 2) + y0
+        y = a * (np.sinc(x) ** 2) + y0
         return y
 
     # pytype: enable=invalid-annotation

--- a/ionics_fits/models/sinusoid.py
+++ b/ionics_fits/models/sinusoid.py
@@ -43,8 +43,8 @@ class Sinusoid(Model):
     def get_num_y_channels(self) -> int:
         return 1
 
-    def can_rescale(self, x_scale: float, y_scale: float) -> bool:
-        return True
+    def can_rescale(self) -> Tuple[bool, bool]:
+        return True, True
 
     # pytype: disable=invalid-annotation
     def _func(

--- a/ionics_fits/models/sinusoid.py
+++ b/ionics_fits/models/sinusoid.py
@@ -1,7 +1,7 @@
-import copy
 import numpy as np
 from typing import Dict, Tuple, TYPE_CHECKING
 
+from . import heuristics
 from .. import common, Model, ModelParameter
 from ..utils import Array
 from . import utils
@@ -90,15 +90,15 @@ class Sinusoid(Model):
         self.parameters["a"].heuristic = spectrum[peak] * 2
         self.parameters["omega"].heuristic = omega[peak]
 
-        phi_params = copy.deepcopy(self.parameters)
-        phi_params["x0"].heuristic = 0.0
-        phi, _ = self.param_min_sqrs(
+        phi, _ = heuristics.param_min_sqrs(
+            model=self,
             x=x,
             y=y,
-            parameters=phi_params,
             scanned_param="phi",
             scanned_param_values=np.linspace(-np.pi, np.pi, num=20),
+            defaults={"x0": 0},
         )
+
         phi = self.parameters["phi"].clip(phi)
 
         if self.parameters["x0"].fixed_to is None:

--- a/ionics_fits/models/triangle.py
+++ b/ionics_fits/models/triangle.py
@@ -34,8 +34,8 @@ class Triangle(Model):
     def get_num_y_channels(self) -> int:
         return 1
 
-    def can_rescale(self, x_scale: float, y_scale: float) -> bool:
-        return True
+    def can_rescale(self) -> Tuple[bool, bool]:
+        return True, True
 
     # pytype: disable=invalid-annotation
     def _func(

--- a/ionics_fits/models/triangle.py
+++ b/ionics_fits/models/triangle.py
@@ -66,30 +66,14 @@ class Triangle(Model):
         self,
         x: Array[("num_samples",), np.float64],
         y: Array[("num_samples",), np.float64],
-        model_parameters: Dict[str, ModelParameter],
     ):
-        """Set heuristic values for model parameters.
-
-        Typically called during `Fitter.fit`. This method may make use of information
-        supplied by the user for some parameters (via the `fixed_to` or
-        `user_estimate` attributes) to find initial guesses for other parameters.
-
-        The datasets must be sorted in order of increasing x-axis values and must not
-        contain any infinite or nan values. If all parameters of the model allow
-        rescaling, then `x`, `y` and `model_parameters` will contain rescaled values.
-
-        :param x: x-axis data, rescaled if allowed.
-        :param y: y-axis data, rescaled if allowed.
-        :param model_parameters: dictionary mapping model parameter names to their
-            metadata, rescaled if allowed.
-        """
         # Ensure that y is a 1D array
         y = np.squeeze(y)
 
         # Written to handle the case of data which is only well-modelled by a
         # triangle function near `x0` but saturates further away
-        model_parameters["y_max"].heuristic = max(y)
-        model_parameters["y_min"].heuristic = min(y)
+        self.parameters["y_max"].heuristic = max(y)
+        self.parameters["y_min"].heuristic = min(y)
 
         min_ind = np.argmin(y)
         max_ind = np.argmax(y)
@@ -115,7 +99,7 @@ class Triangle(Model):
         k_p = (y_r[right_peak_ind] - y_min) / dx_r if dx_r != 0 else 0
         alpha = 0 if k_m == 0 else k_p / k_m
 
-        positive_parameters = copy.deepcopy(model_parameters)
+        positive_parameters = copy.deepcopy(self.parameters)
         positive_parameters["x0"].heuristic = x_min
         positive_parameters["y0"].heuristic = y_min
 
@@ -146,7 +130,7 @@ class Triangle(Model):
         k_p = (y_r[right_peak_ind] - y_max) / dx_r if dx_r != 0 else 0
         alpha = 0 if k_m == 0 else k_p / k_m
 
-        negative_parameters = copy.deepcopy(model_parameters)
+        negative_parameters = copy.deepcopy(self.parameters)
         negative_parameters["x0"].heuristic = x_max
         negative_parameters["y0"].heuristic = y_max
         negative_parameters["k"].heuristic = 0.5 * (k_p + k_m)
@@ -166,7 +150,7 @@ class Triangle(Model):
             best_params = negative_parameters
 
         for param, value in best_params.items():
-            model_parameters[param].heuristic = value
+            self.parameters[param].heuristic = value
 
     def calculate_derived_params(
         self,

--- a/ionics_fits/models/triangle.py
+++ b/ionics_fits/models/triangle.py
@@ -110,9 +110,7 @@ class Triangle(Model):
             param: param_data.get_initial_value()
             for param, param_data in positive_parameters.items()
         }
-        positive_residuals = np.sum(
-            np.power(y - self._func(x, **positive_parameters), 2)
-        )
+        positive_residuals = np.sum((y - self._func(x, **positive_parameters)) ** 2)
 
         # Case 2: negative slope with peaks left and right of x_max below y_max
         x_l = x[x <= x_max]
@@ -140,9 +138,7 @@ class Triangle(Model):
             param: param_data.get_initial_value()
             for param, param_data in negative_parameters.items()
         }
-        negative_residuals = np.sum(
-            np.power(y - self._func(x, **negative_parameters), 2)
-        )
+        negative_residuals = np.sum((y - self._func(x, **negative_parameters)) ** 2)
 
         if positive_residuals < negative_residuals:
             best_params = positive_parameters

--- a/ionics_fits/models/utils.py
+++ b/ionics_fits/models/utils.py
@@ -60,11 +60,10 @@ def rescale_model_x(model_class: TModel, x_scale: float) -> TModel:
             self,
             x: Array[("num_samples",), np.float64],
             y: Array[("num_samples", "num_y_channels"), np.float64],
-            model_parameters: Dict[str, ModelParameter],
         ):
             # avoid double rescaling if estimate_parameters calls self.func internally
             self.__rescale = False
-            super().estimate_parameters(x * self.__x_scale, y, model_parameters)
+            super().estimate_parameters(x * self.__x_scale, y)
             self.__rescale = True
 
     ScaledModel.__name__ = model_class.__name__

--- a/ionics_fits/normal.py
+++ b/ionics_fits/normal.py
@@ -163,7 +163,7 @@ class NormalFitter(Fitter):
             )
 
         y_fit = self.model.func(x, self.values)
-        chi_2 = np.sum(np.power((y - y_fit) / sigma, 2))
+        chi_2 = np.sum(((y - y_fit) / sigma) ** 2)
         p = stats.chi2.sf(chi_2, n)
 
         return p

--- a/ionics_fits/normal.py
+++ b/ionics_fits/normal.py
@@ -42,7 +42,8 @@ class NormalFitter(Fitter):
         :param sigma: optional y-axis standard deviations.
         :param model: the model function to fit to. The model's parameter dictionary is
             used to configure the fit (set parameter bounds etc). Modify this before
-            fitting to change the fit behaviour from the model class' defaults.
+            fitting to change the fit behaviour from the model class' defaults. The
+            model is (deep) copied and stored as an attribute.
         :param curve_fit_args: optional dictionary of keyword arguments to be passed
             into scipy.curve_fit.
         """

--- a/ionics_fits/normal.py
+++ b/ionics_fits/normal.py
@@ -33,6 +33,7 @@ class NormalFitter(Fitter):
         sigma: Optional[
             ArrayLike[("num_y_channels", "num_samples"), np.float64]
         ] = None,
+        curve_fit_args: Optional[Dict] = None,
     ):
         """Fits a model to a dataset and stores the results.
 
@@ -42,11 +43,17 @@ class NormalFitter(Fitter):
         :param model: the model function to fit to. The model's parameter dictionary is
             used to configure the fit (set parameter bounds etc). Modify this before
             fitting to change the fit behaviour from the model class' defaults.
+        :param curve_fit_args: optional dictionary of keyword arguments to be passed
+            into scipy.curve_fit.
         """
         if sigma is None:
             self.sigma = None
         else:
             self.sigma = np.array(sigma, dtype=np.float64, copy=True)
+
+        self.curve_fit_args = {"method": "trf"}
+        if curve_fit_args is not None:
+            self.curve_fit_args.update(curve_fit_args)
 
         super().__init__(x=x, y=y, model=model)
 
@@ -112,7 +119,7 @@ class NormalFitter(Fitter):
             sigma=sigma_flat,
             absolute_sigma=sigma is not None,
             bounds=(lower, upper),
-            method="trf",
+            **self.curve_fit_args,
         )
 
         p_err = np.sqrt(np.diag(p_cov))

--- a/poetry.lock
+++ b/poetry.lock
@@ -192,59 +192,59 @@ pyflakes = ">=2.4.0,<2.5.0"
 
 [[package]]
 name = "fonttools"
-version = "4.43.1"
+version = "4.47.0"
 description = "Tools to manipulate font files"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "fonttools-4.43.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:bf11e2cca121df35e295bd34b309046c29476ee739753bc6bc9d5050de319273"},
-    {file = "fonttools-4.43.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:10b3922875ffcba636674f406f9ab9a559564fdbaa253d66222019d569db869c"},
-    {file = "fonttools-4.43.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9f727c3e3d08fd25352ed76cc3cb61486f8ed3f46109edf39e5a60fc9fecf6ca"},
-    {file = "fonttools-4.43.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ad0b3f6342cfa14be996971ea2b28b125ad681c6277c4cd0fbdb50340220dfb6"},
-    {file = "fonttools-4.43.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:3b7ad05b2beeebafb86aa01982e9768d61c2232f16470f9d0d8e385798e37184"},
-    {file = "fonttools-4.43.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:4c54466f642d2116686268c3e5f35ebb10e49b0d48d41a847f0e171c785f7ac7"},
-    {file = "fonttools-4.43.1-cp310-cp310-win32.whl", hash = "sha256:1e09da7e8519e336239fbd375156488a4c4945f11c4c5792ee086dd84f784d02"},
-    {file = "fonttools-4.43.1-cp310-cp310-win_amd64.whl", hash = "sha256:1cf9e974f63b1080b1d2686180fc1fbfd3bfcfa3e1128695b5de337eb9075cef"},
-    {file = "fonttools-4.43.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:5db46659cfe4e321158de74c6f71617e65dc92e54980086823a207f1c1c0e24b"},
-    {file = "fonttools-4.43.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1952c89a45caceedf2ab2506d9a95756e12b235c7182a7a0fff4f5e52227204f"},
-    {file = "fonttools-4.43.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9c36da88422e0270fbc7fd959dc9749d31a958506c1d000e16703c2fce43e3d0"},
-    {file = "fonttools-4.43.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7bbbf8174501285049e64d174e29f9578495e1b3b16c07c31910d55ad57683d8"},
-    {file = "fonttools-4.43.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:d4071bd1c183b8d0b368cc9ed3c07a0f6eb1bdfc4941c4c024c49a35429ac7cd"},
-    {file = "fonttools-4.43.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:d21099b411e2006d3c3e1f9aaf339e12037dbf7bf9337faf0e93ec915991f43b"},
-    {file = "fonttools-4.43.1-cp311-cp311-win32.whl", hash = "sha256:b84a1c00f832feb9d0585ca8432fba104c819e42ff685fcce83537e2e7e91204"},
-    {file = "fonttools-4.43.1-cp311-cp311-win_amd64.whl", hash = "sha256:9a2f0aa6ca7c9bc1058a9d0b35483d4216e0c1bbe3962bc62ce112749954c7b8"},
-    {file = "fonttools-4.43.1-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:4d9740e3783c748521e77d3c397dc0662062c88fd93600a3c2087d3d627cd5e5"},
-    {file = "fonttools-4.43.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:884ef38a5a2fd47b0c1291647b15f4e88b9de5338ffa24ee52c77d52b4dfd09c"},
-    {file = "fonttools-4.43.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9648518ef687ba818db3fcc5d9aae27a369253ac09a81ed25c3867e8657a0680"},
-    {file = "fonttools-4.43.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95e974d70238fc2be5f444fa91f6347191d0e914d5d8ae002c9aa189572cc215"},
-    {file = "fonttools-4.43.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:34f713dad41aa21c637b4e04fe507c36b986a40f7179dcc86402237e2d39dcd3"},
-    {file = "fonttools-4.43.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:360201d46165fc0753229afe785900bc9596ee6974833124f4e5e9f98d0f592b"},
-    {file = "fonttools-4.43.1-cp312-cp312-win32.whl", hash = "sha256:bb6d2f8ef81ea076877d76acfb6f9534a9c5f31dc94ba70ad001267ac3a8e56f"},
-    {file = "fonttools-4.43.1-cp312-cp312-win_amd64.whl", hash = "sha256:25d3da8a01442cbc1106490eddb6d31d7dffb38c1edbfabbcc8db371b3386d72"},
-    {file = "fonttools-4.43.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:8da417431bfc9885a505e86ba706f03f598c85f5a9c54f67d63e84b9948ce590"},
-    {file = "fonttools-4.43.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:51669b60ee2a4ad6c7fc17539a43ffffc8ef69fd5dbed186a38a79c0ac1f5db7"},
-    {file = "fonttools-4.43.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:748015d6f28f704e7d95cd3c808b483c5fb87fd3eefe172a9da54746ad56bfb6"},
-    {file = "fonttools-4.43.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f7a58eb5e736d7cf198eee94844b81c9573102ae5989ebcaa1d1a37acd04b33d"},
-    {file = "fonttools-4.43.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:6bb5ea9076e0e39defa2c325fc086593ae582088e91c0746bee7a5a197be3da0"},
-    {file = "fonttools-4.43.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:5f37e31291bf99a63328668bb83b0669f2688f329c4c0d80643acee6e63cd933"},
-    {file = "fonttools-4.43.1-cp38-cp38-win32.whl", hash = "sha256:9c60ecfa62839f7184f741d0509b5c039d391c3aff71dc5bc57b87cc305cff3b"},
-    {file = "fonttools-4.43.1-cp38-cp38-win_amd64.whl", hash = "sha256:fe9b1ec799b6086460a7480e0f55c447b1aca0a4eecc53e444f639e967348896"},
-    {file = "fonttools-4.43.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:13a9a185259ed144def3682f74fdcf6596f2294e56fe62dfd2be736674500dba"},
-    {file = "fonttools-4.43.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b2adca1b46d69dce4a37eecc096fe01a65d81a2f5c13b25ad54d5430ae430b13"},
-    {file = "fonttools-4.43.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:18eefac1b247049a3a44bcd6e8c8fd8b97f3cad6f728173b5d81dced12d6c477"},
-    {file = "fonttools-4.43.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2062542a7565091cea4cc14dd99feff473268b5b8afdee564f7067dd9fff5860"},
-    {file = "fonttools-4.43.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:18a2477c62a728f4d6e88c45ee9ee0229405e7267d7d79ce1f5ce0f3e9f8ab86"},
-    {file = "fonttools-4.43.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a7a06f8d95b7496e53af80d974d63516ffb263a468e614978f3899a6df52d4b3"},
-    {file = "fonttools-4.43.1-cp39-cp39-win32.whl", hash = "sha256:10003ebd81fec0192c889e63a9c8c63f88c7d72ae0460b7ba0cd2a1db246e5ad"},
-    {file = "fonttools-4.43.1-cp39-cp39-win_amd64.whl", hash = "sha256:e117a92b07407a061cde48158c03587ab97e74e7d73cb65e6aadb17af191162a"},
-    {file = "fonttools-4.43.1-py3-none-any.whl", hash = "sha256:4f88cae635bfe4bbbdc29d479a297bb525a94889184bb69fa9560c2d4834ddb9"},
-    {file = "fonttools-4.43.1.tar.gz", hash = "sha256:17dbc2eeafb38d5d0e865dcce16e313c58265a6d2d20081c435f84dc5a9d8212"},
+    {file = "fonttools-4.47.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:2d2404107626f97a221dc1a65b05396d2bb2ce38e435f64f26ed2369f68675d9"},
+    {file = "fonttools-4.47.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c01f409be619a9a0f5590389e37ccb58b47264939f0e8d58bfa1f3ba07d22671"},
+    {file = "fonttools-4.47.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d986b66ff722ef675b7ee22fbe5947a41f60a61a4da15579d5e276d897fbc7fa"},
+    {file = "fonttools-4.47.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e8acf6dd0434b211b3bd30d572d9e019831aae17a54016629fa8224783b22df8"},
+    {file = "fonttools-4.47.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:495369c660e0c27233e3c572269cbe520f7f4978be675f990f4005937337d391"},
+    {file = "fonttools-4.47.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:c59227d7ba5b232281c26ae04fac2c73a79ad0e236bca5c44aae904a18f14faf"},
+    {file = "fonttools-4.47.0-cp310-cp310-win32.whl", hash = "sha256:59a6c8b71a245800e923cb684a2dc0eac19c56493e2f896218fcf2571ed28984"},
+    {file = "fonttools-4.47.0-cp310-cp310-win_amd64.whl", hash = "sha256:52c82df66201f3a90db438d9d7b337c7c98139de598d0728fb99dab9fd0495ca"},
+    {file = "fonttools-4.47.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:854421e328d47d70aa5abceacbe8eef231961b162c71cbe7ff3f47e235e2e5c5"},
+    {file = "fonttools-4.47.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:511482df31cfea9f697930f61520f6541185fa5eeba2fa760fe72e8eee5af88b"},
+    {file = "fonttools-4.47.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce0e2c88c8c985b7b9a7efcd06511fb0a1fe3ddd9a6cd2895ef1dbf9059719d7"},
+    {file = "fonttools-4.47.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e7a0a8848726956e9d9fb18c977a279013daadf0cbb6725d2015a6dd57527992"},
+    {file = "fonttools-4.47.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:e869da810ae35afb3019baa0d0306cdbab4760a54909c89ad8904fa629991812"},
+    {file = "fonttools-4.47.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:dd23848f877c3754f53a4903fb7a593ed100924f9b4bff7d5a4e2e8a7001ae11"},
+    {file = "fonttools-4.47.0-cp311-cp311-win32.whl", hash = "sha256:bf1810635c00f7c45d93085611c995fc130009cec5abdc35b327156aa191f982"},
+    {file = "fonttools-4.47.0-cp311-cp311-win_amd64.whl", hash = "sha256:61df4dee5d38ab65b26da8efd62d859a1eef7a34dcbc331299a28e24d04c59a7"},
+    {file = "fonttools-4.47.0-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:e3f4d61f3a8195eac784f1d0c16c0a3105382c1b9a74d99ac4ba421da39a8826"},
+    {file = "fonttools-4.47.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:174995f7b057e799355b393e97f4f93ef1f2197cbfa945e988d49b2a09ecbce8"},
+    {file = "fonttools-4.47.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ea592e6a09b71cb7a7661dd93ac0b877a6228e2d677ebacbad0a4d118494c86d"},
+    {file = "fonttools-4.47.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:40bdbe90b33897d9cc4a39f8e415b0fcdeae4c40a99374b8a4982f127ff5c767"},
+    {file = "fonttools-4.47.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:843509ae9b93db5aaf1a6302085e30bddc1111d31e11d724584818f5b698f500"},
+    {file = "fonttools-4.47.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:9acfa1cdc479e0dde528b61423855913d949a7f7fe09e276228298fef4589540"},
+    {file = "fonttools-4.47.0-cp312-cp312-win32.whl", hash = "sha256:66c92ec7f95fd9732550ebedefcd190a8d81beaa97e89d523a0d17198a8bda4d"},
+    {file = "fonttools-4.47.0-cp312-cp312-win_amd64.whl", hash = "sha256:e8fa20748de55d0021f83754b371432dca0439e02847962fc4c42a0e444c2d78"},
+    {file = "fonttools-4.47.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:c75e19971209fbbce891ebfd1b10c37320a5a28e8d438861c21d35305aedb81c"},
+    {file = "fonttools-4.47.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:e79f1a3970d25f692bbb8c8c2637e621a66c0d60c109ab48d4a160f50856deff"},
+    {file = "fonttools-4.47.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:562681188c62c024fe2c611b32e08b8de2afa00c0c4e72bed47c47c318e16d5c"},
+    {file = "fonttools-4.47.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a77a60315c33393b2bd29d538d1ef026060a63d3a49a9233b779261bad9c3f71"},
+    {file = "fonttools-4.47.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:b4fabb8cc9422efae1a925160083fdcbab8fdc96a8483441eb7457235df625bd"},
+    {file = "fonttools-4.47.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:2a78dba8c2a1e9d53a0fb5382979f024200dc86adc46a56cbb668a2249862fda"},
+    {file = "fonttools-4.47.0-cp38-cp38-win32.whl", hash = "sha256:e6b968543fde4119231c12c2a953dcf83349590ca631ba8216a8edf9cd4d36a9"},
+    {file = "fonttools-4.47.0-cp38-cp38-win_amd64.whl", hash = "sha256:4a9a51745c0439516d947480d4d884fa18bd1458e05b829e482b9269afa655bc"},
+    {file = "fonttools-4.47.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:62d8ddb058b8e87018e5dc26f3258e2c30daad4c87262dfeb0e2617dd84750e6"},
+    {file = "fonttools-4.47.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:5dde0eab40faaa5476133123f6a622a1cc3ac9b7af45d65690870620323308b4"},
+    {file = "fonttools-4.47.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f4da089f6dfdb822293bde576916492cd708c37c2501c3651adde39804630538"},
+    {file = "fonttools-4.47.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:253bb46bab970e8aae254cebf2ae3db98a4ef6bd034707aa68a239027d2b198d"},
+    {file = "fonttools-4.47.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:1193fb090061efa2f9e2d8d743ae9850c77b66746a3b32792324cdce65784154"},
+    {file = "fonttools-4.47.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:084511482dd265bce6dca24c509894062f0117e4e6869384d853f46c0e6d43be"},
+    {file = "fonttools-4.47.0-cp39-cp39-win32.whl", hash = "sha256:97620c4af36e4c849e52661492e31dc36916df12571cb900d16960ab8e92a980"},
+    {file = "fonttools-4.47.0-cp39-cp39-win_amd64.whl", hash = "sha256:e77bdf52185bdaf63d39f3e1ac3212e6cfa3ab07d509b94557a8902ce9c13c82"},
+    {file = "fonttools-4.47.0-py3-none-any.whl", hash = "sha256:d6477ba902dd2d7adda7f0fd3bfaeb92885d45993c9e1928c9f28fc3961415f7"},
+    {file = "fonttools-4.47.0.tar.gz", hash = "sha256:ec13a10715eef0e031858c1c23bfaee6cba02b97558e4a7bfa089dba4a8c2ebf"},
 ]
 
 [package.extras]
-all = ["brotli (>=1.0.1)", "brotlicffi (>=0.8.0)", "fs (>=2.2.0,<3)", "lxml (>=4.0,<5)", "lz4 (>=1.7.4.2)", "matplotlib", "munkres", "scipy", "skia-pathops (>=0.5.0)", "sympy", "uharfbuzz (>=0.23.0)", "unicodedata2 (>=15.0.0)", "xattr", "zopfli (>=0.1.4)"]
+all = ["brotli (>=1.0.1)", "brotlicffi (>=0.8.0)", "fs (>=2.2.0,<3)", "lxml (>=4.0,<5)", "lz4 (>=1.7.4.2)", "matplotlib", "munkres", "pycairo", "scipy", "skia-pathops (>=0.5.0)", "sympy", "uharfbuzz (>=0.23.0)", "unicodedata2 (>=15.1.0)", "xattr", "zopfli (>=0.1.4)"]
 graphite = ["lz4 (>=1.7.4.2)"]
-interpolatable = ["munkres", "scipy"]
+interpolatable = ["munkres", "pycairo", "scipy"]
 lxml = ["lxml (>=4.0,<5)"]
 pathops = ["skia-pathops (>=0.5.0)"]
 plot = ["matplotlib"]
@@ -252,7 +252,7 @@ repacker = ["uharfbuzz (>=0.23.0)"]
 symfont = ["sympy"]
 type1 = ["xattr"]
 ufo = ["fs (>=2.2.0,<3)"]
-unicode = ["unicodedata2 (>=15.0.0)"]
+unicode = ["unicodedata2 (>=15.1.0)"]
 woff = ["brotli (>=1.0.1)", "brotlicffi (>=0.8.0)", "zopfli (>=0.1.4)"]
 
 [[package]]
@@ -271,13 +271,13 @@ networkx = ">=2"
 
 [[package]]
 name = "importlib-resources"
-version = "6.1.0"
+version = "6.1.1"
 description = "Read resources from Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "importlib_resources-6.1.0-py3-none-any.whl", hash = "sha256:aa50258bbfa56d4e33fbd8aa3ef48ded10d1735f11532b8df95388cc6bdb7e83"},
-    {file = "importlib_resources-6.1.0.tar.gz", hash = "sha256:9d48dcccc213325e810fd723e7fbb45ccb39f6cf5c31f00cf2b965f5f10f3cb9"},
+    {file = "importlib_resources-6.1.1-py3-none-any.whl", hash = "sha256:e8bf90d8213b486f428c9c39714b920041cb02c184686a3dee24905aaa8105d6"},
+    {file = "importlib_resources-6.1.1.tar.gz", hash = "sha256:3893a00122eafde6894c59914446a512f728a0c1a45f9bb9b63721b6bacf0b4a"},
 ]
 
 [package.dependencies]
@@ -503,6 +503,16 @@ files = [
     {file = "MarkupSafe-2.1.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:5bbe06f8eeafd38e5d0a4894ffec89378b6c6a625ff57e3028921f8ff59318ac"},
     {file = "MarkupSafe-2.1.3-cp311-cp311-win32.whl", hash = "sha256:dd15ff04ffd7e05ffcb7fe79f1b98041b8ea30ae9234aed2a9168b5797c3effb"},
     {file = "MarkupSafe-2.1.3-cp311-cp311-win_amd64.whl", hash = "sha256:134da1eca9ec0ae528110ccc9e48041e0828d79f24121a1a146161103c76e686"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:f698de3fd0c4e6972b92290a45bd9b1536bffe8c6759c62471efaa8acb4c37bc"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:aa57bd9cf8ae831a362185ee444e15a93ecb2e344c8e52e4d721ea3ab6ef1823"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ffcc3f7c66b5f5b7931a5aa68fc9cecc51e685ef90282f4a82f0f5e9b704ad11"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47d4f1c5f80fc62fdd7777d0d40a2e9dda0a05883ab11374334f6c4de38adffd"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1f67c7038d560d92149c060157d623c542173016c4babc0c1913cca0564b9939"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:9aad3c1755095ce347e26488214ef77e0485a3c34a50c5a5e2471dff60b9dd9c"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:14ff806850827afd6b07a5f32bd917fb7f45b046ba40c57abdb636674a8b559c"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8f9293864fe09b8149f0cc42ce56e3f0e54de883a9de90cd427f191c346eb2e1"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-win32.whl", hash = "sha256:715d3562f79d540f251b99ebd6d8baa547118974341db04f5ad06d5ea3eb8007"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-win_amd64.whl", hash = "sha256:1b8dd8c3fd14349433c79fa8abeb573a55fc0fdd769133baac1f5e07abf54aeb"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8e254ae696c88d98da6555f5ace2279cf7cd5b3f52be2b5cf97feafe883b58d2"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cb0932dc158471523c9637e807d9bfb93e06a95cbf010f1a38b98623b929ef2b"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9402b03f1a1b4dc4c19845e5c749e3ab82d5078d16a2a4c2cd2df62d57bb0707"},
@@ -537,58 +547,58 @@ files = [
 
 [[package]]
 name = "matplotlib"
-version = "3.7.3"
+version = "3.7.4"
 description = "Python plotting package"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "matplotlib-3.7.3-cp310-cp310-macosx_10_12_universal2.whl", hash = "sha256:085c33b27561d9c04386789d5aa5eb4a932ddef43cfcdd0e01735f9a6e85ce0c"},
-    {file = "matplotlib-3.7.3-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:c568e80e1c17f68a727f30f591926751b97b98314d8e59804f54f86ae6fa6a22"},
-    {file = "matplotlib-3.7.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:7baf98c5ad59c5c4743ea884bb025cbffa52dacdfdac0da3e6021a285a90377e"},
-    {file = "matplotlib-3.7.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:236024f582e40dac39bca592258888b38ae47a9fed7b8de652d68d3d02d47d2b"},
-    {file = "matplotlib-3.7.3-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:12b4f6795efea037ce2d41e7c417ad8bd02d5719c6ad4a8450a0708f4a1cfb89"},
-    {file = "matplotlib-3.7.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:78b2136cc6c5415b78977e0e8c608647d597204b05b1d9089ccf513c7d913733"},
-    {file = "matplotlib-3.7.3-cp310-cp310-win32.whl", hash = "sha256:122dcbf9be0086e2a95d9e5e0632dbf3bd5b65eaa68c369363310a6c87753059"},
-    {file = "matplotlib-3.7.3-cp310-cp310-win_amd64.whl", hash = "sha256:4aab27d9e33293389e3c1d7c881d414a72bdfda0fedc3a6bf46c6fa88d9b8015"},
-    {file = "matplotlib-3.7.3-cp311-cp311-macosx_10_12_universal2.whl", hash = "sha256:d5adc743de91e8e0b13df60deb1b1c285b8effea3d66223afceb14b63c9b05de"},
-    {file = "matplotlib-3.7.3-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:55de4cf7cd0071b8ebf203981b53ab64f988a0a1f897a2dff300a1124e8bcd8b"},
-    {file = "matplotlib-3.7.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ac03377fd908aaee2312d0b11735753e907adb6f4d1d102de5e2425249693f6c"},
-    {file = "matplotlib-3.7.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:755bafc10a46918ce9a39980009b54b02dd249594e5adf52f9c56acfddb5d0b7"},
-    {file = "matplotlib-3.7.3-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1a6094c6f8e8d18db631754df4fe9a34dec3caf074f6869a7db09f18f9b1d6b2"},
-    {file = "matplotlib-3.7.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:272dba2f1b107790ed78ebf5385b8d14b27ad9e90419de340364b49fe549a993"},
-    {file = "matplotlib-3.7.3-cp311-cp311-win32.whl", hash = "sha256:591c123bed1cb4b9996fb60b41a6d89c2ec4943244540776c5f1283fb6960a53"},
-    {file = "matplotlib-3.7.3-cp311-cp311-win_amd64.whl", hash = "sha256:3bf3a178c6504694cee8b88b353df0051583f2f6f8faa146f67115c27c856881"},
-    {file = "matplotlib-3.7.3-cp312-cp312-macosx_10_12_universal2.whl", hash = "sha256:edf54cac8ee3603f3093616b40a931e8c063969756a4d78a86e82c2fea9659f7"},
-    {file = "matplotlib-3.7.3-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:91e36a85ea639a1ba9f91427041eac064b04829945fe331a92617b6cb21d27e5"},
-    {file = "matplotlib-3.7.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:caf5eaaf7c68f8d7df269dfbcaf46f48a70ff482bfcebdcc97519671023f2a7d"},
-    {file = "matplotlib-3.7.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:74bf57f505efea376097e948b7cdd87191a7ce8180616390aef496639edf601f"},
-    {file = "matplotlib-3.7.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ee152a88a0da527840a426535514b6ed8ac4240eb856b1da92cf48124320e346"},
-    {file = "matplotlib-3.7.3-cp312-cp312-win_amd64.whl", hash = "sha256:67a410a9c9e07cbc83581eeea144bbe298870bf0ac0ee2f2e10a015ab7efee19"},
-    {file = "matplotlib-3.7.3-cp38-cp38-macosx_10_12_universal2.whl", hash = "sha256:259999c05285cb993d7f2a419cea547863fa215379eda81f7254c9e932963729"},
-    {file = "matplotlib-3.7.3-cp38-cp38-macosx_10_12_x86_64.whl", hash = "sha256:3f4e7fd5a6157e1d018ce2166ec8e531a481dd4a36f035b5c23edfe05a25419a"},
-    {file = "matplotlib-3.7.3-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:faa3d12d8811d08d14080a8b7b9caea9a457dc495350166b56df0db4b9909ef5"},
-    {file = "matplotlib-3.7.3-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:336e88900c11441e458da01c8414fc57e04e17f9d3bb94958a76faa2652bcf6b"},
-    {file = "matplotlib-3.7.3-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:12f4c0dd8aa280d796c8772ea8265a14f11a04319baa3a16daa5556065e8baea"},
-    {file = "matplotlib-3.7.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1990955b11e7918d256cf3b956b10997f405b7917a3f1c7d8e69c1d15c7b1930"},
-    {file = "matplotlib-3.7.3-cp38-cp38-win32.whl", hash = "sha256:e78707b751260b42b721507ad7aa60fe4026d7f51c74cca6b9cd8b123ebb633a"},
-    {file = "matplotlib-3.7.3-cp38-cp38-win_amd64.whl", hash = "sha256:e594ee43c59ea39ca5c6244667cac9d017a3527febc31f5532ad9135cf7469ec"},
-    {file = "matplotlib-3.7.3-cp39-cp39-macosx_10_12_universal2.whl", hash = "sha256:6eaa1cf0e94c936a26b78f6d756c5fbc12e0a58c8a68b7248a2a31456ce4e234"},
-    {file = "matplotlib-3.7.3-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:0a97af9d22e8ebedc9f00b043d9bbd29a375e9e10b656982012dded44c10fd77"},
-    {file = "matplotlib-3.7.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:1f9c6c16597af660433ab330b59ee2934b832ee1fabcaf5cbde7b2add840f31e"},
-    {file = "matplotlib-3.7.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a7240259b4b9cbc62381f6378cff4d57af539162a18e832c1e48042fabc40b6b"},
-    {file = "matplotlib-3.7.3-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:747c6191d2e88ae854809e69aa358dbf852ff1a5738401b85c1cc9012309897a"},
-    {file = "matplotlib-3.7.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ec726b08a5275d827aa91bb951e68234a4423adb91cf65bc0fcdc0f2777663f7"},
-    {file = "matplotlib-3.7.3-cp39-cp39-win32.whl", hash = "sha256:40e3b9b450c6534f07278310c4e34caff41c2a42377e4b9d47b0f8d3ac1083a2"},
-    {file = "matplotlib-3.7.3-cp39-cp39-win_amd64.whl", hash = "sha256:dfc118642903a23e309b1da32886bb39a4314147d013e820c86b5fb4cb2e36d0"},
-    {file = "matplotlib-3.7.3-pp38-pypy38_pp73-macosx_10_12_x86_64.whl", hash = "sha256:165c8082bf8fc0360c24aa4724a22eaadbfd8c28bf1ccf7e94d685cad48261e4"},
-    {file = "matplotlib-3.7.3-pp38-pypy38_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ebd8470cc2a3594746ff0513aecbfa2c55ff6f58e6cef2efb1a54eb87c88ffa2"},
-    {file = "matplotlib-3.7.3-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7153453669c9672b52095119fd21dd032d19225d48413a2871519b17db4b0fde"},
-    {file = "matplotlib-3.7.3-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:498a08267dc69dd8f24c4b5d7423fa584d7ce0027ba71f7881df05fc09b89bb7"},
-    {file = "matplotlib-3.7.3-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:d48999c4b19b5a0c058c9cd828ff6fc7748390679f6cf9a2ad653a3e802c87d3"},
-    {file = "matplotlib-3.7.3-pp39-pypy39_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:22d65d18b4ee8070a5fea5761d59293f1f9e2fac37ec9ce090463b0e629432fd"},
-    {file = "matplotlib-3.7.3-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9c40cde976c36693cc0767e27cf5f443f91c23520060bd9496678364adfafe9c"},
-    {file = "matplotlib-3.7.3-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:39018a2b17592448fbfdf4b8352955e6c3905359939791d4ff429296494d1a0c"},
-    {file = "matplotlib-3.7.3.tar.gz", hash = "sha256:f09b3dd6bdeb588de91f853bbb2d6f0ff8ab693485b0c49035eaa510cb4f142e"},
+    {file = "matplotlib-3.7.4-cp310-cp310-macosx_10_12_universal2.whl", hash = "sha256:b71079239bd866bf56df023e5146de159cb0c7294e508830901f4d79e2d89385"},
+    {file = "matplotlib-3.7.4-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:bf91a42f6274a64cb41189120b620c02e574535ff6671fa836cade7701b06fbd"},
+    {file = "matplotlib-3.7.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f757e8b42841d6add0cb69b42497667f0d25a404dcd50bd923ec9904e38414c4"},
+    {file = "matplotlib-3.7.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e4dfee00aa4bd291e08bb9461831c26ce0da85ca9781bb8794f2025c6e925281"},
+    {file = "matplotlib-3.7.4-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3640f33632beb3993b698b1be9d1c262b742761d6101f3c27b87b2185d25c875"},
+    {file = "matplotlib-3.7.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ff539c4a17ecdf076ed808ee271ffae4a30dcb7e157b99ccae2c837262c07db6"},
+    {file = "matplotlib-3.7.4-cp310-cp310-win32.whl", hash = "sha256:24b8f28af3e766195c09b780b15aa9f6710192b415ae7866b9c03dee7ec86370"},
+    {file = "matplotlib-3.7.4-cp310-cp310-win_amd64.whl", hash = "sha256:3fa193286712c3b6c3cfa5fe8a6bb563f8c52cc750006c782296e0807ce5e799"},
+    {file = "matplotlib-3.7.4-cp311-cp311-macosx_10_12_universal2.whl", hash = "sha256:b167f54cb4654b210c9624ec7b54e2b3b8de68c93a14668937e7e53df60770ec"},
+    {file = "matplotlib-3.7.4-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:7dfe6821f1944cb35603ff22e21510941bbcce7ccf96095beffaac890d39ce77"},
+    {file = "matplotlib-3.7.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3c557d9165320dff3c5f2bb99bfa0b6813d3e626423ff71c40d6bc23b83c3339"},
+    {file = "matplotlib-3.7.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:08372696b3bb45c563472a552a705bfa0942f0a8ffe084db8a4e8f9153fbdf9d"},
+    {file = "matplotlib-3.7.4-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:81e1a7ac818000e8ac3ca696c3fdc501bc2d3adc89005e7b4e22ee5e9d51de98"},
+    {file = "matplotlib-3.7.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:390920a3949906bc4b0216198d378f2a640c36c622e3584dd0c79a7c59ae9f50"},
+    {file = "matplotlib-3.7.4-cp311-cp311-win32.whl", hash = "sha256:62e094d8da26294634da9e7f1856beee3978752b1b530c8e1763d2faed60cc10"},
+    {file = "matplotlib-3.7.4-cp311-cp311-win_amd64.whl", hash = "sha256:f8fc2df756105784e650605e024d36dc2d048d68e5c1b26df97ee25d1bd41f9f"},
+    {file = "matplotlib-3.7.4-cp312-cp312-macosx_10_12_universal2.whl", hash = "sha256:568574756127791903604e315c11aef9f255151e4cfe20ec603a70f9dda8e259"},
+    {file = "matplotlib-3.7.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:7d479aac338195e2199a8cfc03c4f2f55914e6a120177edae79e0340a6406457"},
+    {file = "matplotlib-3.7.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:32183d4be84189a4c52b4b8861434d427d9118db2cec32986f98ed6c02dcfbb6"},
+    {file = "matplotlib-3.7.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0037d066cca1f4bda626c507cddeb6f7da8283bc6a214da2db13ff2162933c52"},
+    {file = "matplotlib-3.7.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:44856632ebce88abd8efdc0a0dceec600418dcac06b72ae77af0019d260aa243"},
+    {file = "matplotlib-3.7.4-cp312-cp312-win_amd64.whl", hash = "sha256:632fc938c22117d4241411191cfb88ac264a4c0a9ac702244641ddf30f0d739c"},
+    {file = "matplotlib-3.7.4-cp38-cp38-macosx_10_12_universal2.whl", hash = "sha256:ce163be048613b9d1962273708cc97e09ca05d37312e670d166cf332b80bbaff"},
+    {file = "matplotlib-3.7.4-cp38-cp38-macosx_10_12_x86_64.whl", hash = "sha256:e680f49bb8052ba3b2698e370155d2b4afb49f9af1cc611a26579d5981e2852a"},
+    {file = "matplotlib-3.7.4-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:0604880e4327114054199108b7390f987f4f40ee5ce728985836889e11a780ba"},
+    {file = "matplotlib-3.7.4-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:1e6abcde6fc52475f9d6a12b9f1792aee171ce7818ef6df5d61cb0b82816e6e8"},
+    {file = "matplotlib-3.7.4-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f59a70e2ec3212033ef6633ed07682da03f5249379722512a3a2a26a7d9a738e"},
+    {file = "matplotlib-3.7.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7a9981b2a2dd9da06eca4ab5855d09b54b8ce7377c3e0e3957767b83219d652d"},
+    {file = "matplotlib-3.7.4-cp38-cp38-win32.whl", hash = "sha256:83859ac26839660ecd164ee8311272074250b915ac300f9b2eccc84410f8953b"},
+    {file = "matplotlib-3.7.4-cp38-cp38-win_amd64.whl", hash = "sha256:7a7709796ac59fe8debde68272388be6ed449c8971362eb5b60d280eac8dadde"},
+    {file = "matplotlib-3.7.4-cp39-cp39-macosx_10_12_universal2.whl", hash = "sha256:b1d70bc1ea1bf110bec64f4578de3e14947909a8887df4c1fd44492eca487955"},
+    {file = "matplotlib-3.7.4-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:c83f49e795a5de6c168876eea723f5b88355202f9603c55977f5356213aa8280"},
+    {file = "matplotlib-3.7.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:5c9133f230945fe10652eb33e43642e933896194ef6a4f8d5e79bb722bdb2000"},
+    {file = "matplotlib-3.7.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:798ff59022eeb276380ce9a73ba35d13c3d1499ab9b73d194fd07f1b0a41c304"},
+    {file = "matplotlib-3.7.4-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1707b20b25e90538c2ce8d4409e30f0ef1df4017cc65ad0439633492a973635b"},
+    {file = "matplotlib-3.7.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8e6227ca8492baeef873cdd8e169a318efb5c3a25ce94e69727e7f964995b0b1"},
+    {file = "matplotlib-3.7.4-cp39-cp39-win32.whl", hash = "sha256:5661c8639aded7d1bbf781373a359011cb1dd09199dee49043e9e68dd16f07ba"},
+    {file = "matplotlib-3.7.4-cp39-cp39-win_amd64.whl", hash = "sha256:55eec941a4743f0bd3e5b8ee180e36b7ea8e62f867bf2613937c9f01b9ac06a2"},
+    {file = "matplotlib-3.7.4-pp38-pypy38_pp73-macosx_10_12_x86_64.whl", hash = "sha256:ab16868714e5cc90ec8f7ff5d83d23bcd6559224d8e9cb5227c9f58748889fe8"},
+    {file = "matplotlib-3.7.4-pp38-pypy38_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0c698b33f9a3f0b127a8e614c8fb4087563bb3caa9c9d95298722fa2400cdd3f"},
+    {file = "matplotlib-3.7.4-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:be3493bbcb4d255cb71de1f9050ac71682fce21a56089eadbcc8e21784cb12ee"},
+    {file = "matplotlib-3.7.4-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:f8c725d1dd2901b2e7ec6cd64165e00da2978cc23d4143cb9ef745bec88e6b04"},
+    {file = "matplotlib-3.7.4-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:286332f8f45f8ffde2d2119b9fdd42153dccd5025fa9f451b4a3b5c086e26da5"},
+    {file = "matplotlib-3.7.4-pp39-pypy39_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:116ef0b43aa00ff69260b4cce39c571e4b8c6f893795b708303fa27d9b9d7548"},
+    {file = "matplotlib-3.7.4-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c90590d4b46458677d80bc3218f3f1ac11fc122baa9134e0cb5b3e8fc3714052"},
+    {file = "matplotlib-3.7.4-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:de7c07069687be64fd9d119da3122ba13a8d399eccd3f844815f0dc78a870b2c"},
+    {file = "matplotlib-3.7.4.tar.gz", hash = "sha256:7cd4fef8187d1dd0d9dcfdbaa06ac326d396fb8c71c647129f0bf56835d77026"},
 ]
 
 [package.dependencies]
@@ -602,7 +612,6 @@ packaging = ">=20.0"
 pillow = ">=6.2.0"
 pyparsing = ">=2.3.1"
 python-dateutil = ">=2.7"
-setuptools_scm = ">=7"
 
 [[package]]
 name = "mccabe"
@@ -798,24 +807,24 @@ files = [
 
 [[package]]
 name = "pathspec"
-version = "0.11.2"
+version = "0.12.1"
 description = "Utility library for gitignore style pattern matching of file paths."
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "pathspec-0.11.2-py3-none-any.whl", hash = "sha256:1d6ed233af05e679efb96b1851550ea95bbb64b7c490b0f5aa52996c11e92a20"},
-    {file = "pathspec-0.11.2.tar.gz", hash = "sha256:e0d8d0ac2f12da61956eb2306b69f9469b42f4deb0f3cb6ed47b9cce9996ced3"},
+    {file = "pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08"},
+    {file = "pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712"},
 ]
 
 [[package]]
 name = "patsy"
-version = "0.5.3"
+version = "0.5.5"
 description = "A Python package for describing statistical models and for building design matrices."
 optional = false
 python-versions = "*"
 files = [
-    {file = "patsy-0.5.3-py2.py3-none-any.whl", hash = "sha256:7eb5349754ed6aa982af81f636479b1b8db9d5b1a6e957a6016ec0534b5c86b7"},
-    {file = "patsy-0.5.3.tar.gz", hash = "sha256:bdc18001875e319bc91c812c1eb6a10be4bb13cb81eb763f466179dca3b67277"},
+    {file = "patsy-0.5.5-py2.py3-none-any.whl", hash = "sha256:6067516e97c1d5da5d24603853834e3555e943ffb419ea32020f7ba561fa6d0d"},
+    {file = "patsy-0.5.5.tar.gz", hash = "sha256:7fbdebd44f1ceb1db2d45d03c19ccb0c424f71dc8e66f0f3eebf87b0ff3a071a"},
 ]
 
 [package.dependencies]
@@ -894,13 +903,13 @@ tests = ["check-manifest", "coverage", "defusedxml", "markdown2", "olefile", "pa
 
 [[package]]
 name = "platformdirs"
-version = "3.11.0"
+version = "4.1.0"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "platformdirs-3.11.0-py3-none-any.whl", hash = "sha256:e9d171d00af68be50e9202731309c4e658fd8bc76f55c11c7dd760d023bda68e"},
-    {file = "platformdirs-3.11.0.tar.gz", hash = "sha256:cf8ee52a3afdb965072dcc652433e0c7e3e40cf5ea1477cd4b3b1d2eb75495b3"},
+    {file = "platformdirs-4.1.0-py3-none-any.whl", hash = "sha256:11c8f37bcca40db96d8144522d925583bdb7a31f7b0e37e3ed4318400a8e2380"},
+    {file = "platformdirs-4.1.0.tar.gz", hash = "sha256:906d548203468492d432bcb294d4bc2fff751bf84971fbb2c10918cc206ee420"},
 ]
 
 [package.extras]
@@ -1244,44 +1253,6 @@ doc = ["matplotlib (>2)", "numpydoc", "pydata-sphinx-theme (==0.9.0)", "sphinx (
 test = ["asv", "gmpy2", "mpmath", "pooch", "pytest", "pytest-cov", "pytest-timeout", "pytest-xdist", "scikit-umfpack", "threadpoolctl"]
 
 [[package]]
-name = "setuptools"
-version = "68.2.2"
-description = "Easily download, build, install, upgrade, and uninstall Python packages"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "setuptools-68.2.2-py3-none-any.whl", hash = "sha256:b454a35605876da60632df1a60f736524eb73cc47bbc9f3f1ef1b644de74fd2a"},
-    {file = "setuptools-68.2.2.tar.gz", hash = "sha256:4ac1475276d2f1c48684874089fefcd83bd7162ddaafb81fac866ba0db282a87"},
-]
-
-[package.extras]
-docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
-testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-ruff", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
-testing-integration = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "packaging (>=23.1)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
-
-[[package]]
-name = "setuptools-scm"
-version = "8.0.4"
-description = "the blessed package to manage your versions by scm tags"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "setuptools-scm-8.0.4.tar.gz", hash = "sha256:b5f43ff6800669595193fd09891564ee9d1d7dcb196cab4b2506d53a2e1c95c7"},
-    {file = "setuptools_scm-8.0.4-py3-none-any.whl", hash = "sha256:b47844cd2a84b83b3187a5782c71128c28b4c94cad8bfb871da2784a5cb54c4f"},
-]
-
-[package.dependencies]
-packaging = ">=20"
-setuptools = "*"
-tomli = {version = ">=1", markers = "python_version < \"3.11\""}
-typing-extensions = "*"
-
-[package.extras]
-docs = ["entangled-cli[rich]", "mkdocs", "mkdocs-entangled-plugin", "mkdocs-material", "mkdocstrings[python]", "pygments"]
-rich = ["rich"]
-test = ["build", "pytest", "rich", "wheel"]
-
-[[package]]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -1423,13 +1394,13 @@ files = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.8.0"
+version = "4.9.0"
 description = "Backported and Experimental Type Hints for Python 3.8+"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "typing_extensions-4.8.0-py3-none-any.whl", hash = "sha256:8f92fc8806f9a6b641eaa5318da32b44d401efaac0f6678c9bc448ba3605faa0"},
-    {file = "typing_extensions-4.8.0.tar.gz", hash = "sha256:df8e4339e9cb77357558cbdbceca33c303714cf861d1eef15e1070055ae8b7ef"},
+    {file = "typing_extensions-4.9.0-py3-none-any.whl", hash = "sha256:af72aea155e91adfc61c3ae9e0e342dbc0cba726d6cba4b6c72c1f34e47291cd"},
+    {file = "typing_extensions-4.9.0.tar.gz", hash = "sha256:23478f88c37f27d76ac8aee6c905017a143b0b1b886c3c9f66bc2fd94f9f5783"},
 ]
 
 [[package]]
@@ -1476,4 +1447,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8, <3.11"
-content-hash = "877c2aa1d5e55f3dc1a0534580cb34ca3a12e96203a70b94623fa5ba8f4991b4"
+content-hash = "3e0aa67e2445dd92bd2e49418095add0ec361496c6d5228fdd20a876f321d556"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,15 +10,14 @@ python = ">=3.8, <3.11"
 numpy = "^1.21.2"
 scipy = "^1.7.1"
 statsmodels = "^0.13.2"
-pyqt5 = "^5.15.9"
-# no windows wheels for 5.15.11 as of 24/10/2023
-pyqt5-qt5 = "^5.15.2, <5.15.11"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"
 poethepoet = "^0.12.1"
 flake8 = "^4.0.1"
 black = "^22.6.0"
+pyqt5 = "^5.15.9"
+pyqt5-qt5 = "^5.15.2, <5.15.11" # no windows wheels for 5.15.11 as of 24/10/2023
 matplotlib = "^3.5.3"
 pytype = {version = "^2022.4.15", markers = "os_name == 'posix'"}
 

--- a/test/test_molmer_sorensen.py
+++ b/test/test_molmer_sorensen.py
@@ -29,6 +29,7 @@ def test_ms_time(plot_failures: bool):
         # There is a lot of covariance between delta and omega, so curvefit will
         # often fail to converge properly no matter how close the heuristic gets
         model.parameters["delta"].fixed_to = 0
+
         common.check_multiple_param_sets(
             t,
             model,
@@ -42,30 +43,30 @@ def test_ms_time(plot_failures: bool):
     _test_ms_time(num_qubits=1, walsh_idx=0, start_excited=True, user_estimates=[])
     for num_qubits in [1, 2]:
         for walsh_idx in [0, 1, 3]:
-            _test_ms_time(
-                num_qubits=num_qubits,
-                walsh_idx=walsh_idx,
-                start_excited=False,
-                user_estimates=[],
-            )
+            # _test_ms_time(
+            #     num_qubits=num_qubits,
+            #     walsh_idx=walsh_idx,
+            #     start_excited=False,
+            #     user_estimates=[],
+            # )
             _test_ms_time(
                 num_qubits=num_qubits,
                 walsh_idx=walsh_idx,
                 start_excited=False,
                 user_estimates=["omega"],
             )
-            _test_ms_time(
-                num_qubits=num_qubits,
-                walsh_idx=walsh_idx,
-                start_excited=False,
-                user_estimates=["delta"],
-            )
-            _test_ms_time(
-                num_qubits=num_qubits,
-                walsh_idx=walsh_idx,
-                start_excited=False,
-                user_estimates=["omega", "delta"],
-            )
+            # _test_ms_time(
+            #     num_qubits=num_qubits,
+            #     walsh_idx=walsh_idx,
+            #     start_excited=False,
+            #     user_estimates=["delta"],
+            # )
+            # _test_ms_time(
+            #     num_qubits=num_qubits,
+            #     walsh_idx=walsh_idx,
+            #     start_excited=False,
+            #     user_estimates=["omega", "delta"],
+            # )
 
 
 def test_ms_freq(plot_failures: bool):

--- a/test/test_molmer_sorensen.py
+++ b/test/test_molmer_sorensen.py
@@ -13,13 +13,12 @@ def test_ms_time(plot_failures: bool):
     """Test for molmer_sorensen.MolmerSorensenTime"""
 
     def _test_ms_time(num_qubits, walsh_idx, start_excited, user_estimates):
-        # https://github.com/OxIonics/ionics_fits/issues/105
-        t = np.linspace(0, 1, 100)
-        t_ref = 0.3
+        t = np.linspace(0, 1, 100) * 1e-6
+        t_ref = 0.3e-6
 
         params = {
             "omega": np.array([0.5, 1, 2]) * np.pi / t_ref,
-            "delta": 0,  # np.array([0.25, 0, -0.125, 0.5]) * np.pi / t_ref,
+            "delta": 0,
             "n_bar": 0,
         }
 


### PR DESCRIPTION
Tidying up a few ugly corners of the design and expanding some features.
-  `Model` now has a concept of `internal_parameters` which are parameters that are not exposed directly to the user, but should be rescaled. These are used, for example, by containers.
-  `Model.estimate_parameters` no longer takes a parameter dictionary as an input. Instead, it acts directly on the model's parameter dictionary
-  it is now mandatory to specify scale functions for all model parameters. This removes a footgun with the previous design where it was easy to forget to specify a scale function, leading to bugs. Some default scale functions have been provided for convenience / readability.
-  scale functions now always return a float. Whether or not a model can be rescaled is decided by overriding the `can_rescale` method, rather than checking for any parameter scale values to be `None`
-  scale functions are no longer passed the model as an input. Any corner-cases which were previously handled by this should now be handled by overriding the model rescale function
-  `can_rescale` now returns a tuple of bools to allow separate control of x-axis and y-axis scaling
-  deal with scaling parameter metadata using `__getattribute__` and `__setattr__`. as well as `rescale` and `unscale` methods. Use these in favor of `get_scaled_model`
- fixed parameters cannot have user estimates
- plotting is now a dev dependency
- heuristics have been moved into `models.heuristics`
- replace `np.power` with the faster and more pythonic `**` operator
- solver arguments are now exposed via fitters
- tidy up / improve documentation around object ownership, removing a number of `deepcopy`s

TODO:
- Function annotation for models not completely correct #100
- https://github.com/OxIonics/ionics_fits/issues/47
- https://github.com/OxIonics/ionics_fits/issues/40
- #127

Closes #105 #81 #115 #118 #106 #91 #126