### PR TITLE
Make Model2D a subclass of Model

### DIFF
--- a/ionics_fits/common.py
+++ b/ionics_fits/common.py
@@ -308,7 +308,22 @@ class Model:
             param_data.unscale()
 
     def get_num_y_channels(self) -> int:
-        """Returns the number of y channels supported by the model."""
+        """Returns the number of y-axis dimensions ("channels") the model has."""
+        raise NotImplementedError
+
+    def clear_heuristics(self):
+        """Clear the heuristics for all model parameters.
+
+        This is mainly used in container-type models, where the parameter estimator
+        my be run multiple times for the same model instance.
+        """
+        for param_data in self.parameters.values():
+            param_data.heuristic = None
+        for param_data in self.internal_parameters:
+            param_data = None
+
+    def get_num_x_axes(self) -> int:
+        """Returns the number of x-axis dimensions the model has."""
         raise NotImplementedError
 
     def func(self, x: TX, param_values: Dict[str, float]) -> TY:

--- a/ionics_fits/models/containers.py
+++ b/ionics_fits/models/containers.py
@@ -248,7 +248,6 @@ class AggregateModel(Model):
                 fit_uncertainties=model_fit_uncertainties,
             )
             model_derived_params, model_derived_uncertainties = derived
-
             derived_params.update(
                 {
                     f"{param_name}_{model_name}": value
@@ -599,6 +598,8 @@ class MappedModel(Model):
             will not be parameters of the new model.
         :param derived_result_mapping: optional dictionary mapping names of derived
             result in the new model to names of derived results in the wrapped model.
+            Derived results may be renamed to `None` to exclude them from the model's
+            outputs.
         """
         self.model = model
         self.derived_result_mapping = derived_result_mapping or {}
@@ -721,6 +722,10 @@ class MappedModel(Model):
         mapping = self.derived_result_mapping
         for derived_dict in derived:
             for new_result_name, model_result_name in mapping.items():
+                if new_result_name is None:
+                    del derived_dict[model_result_name]
+                    continue
+
                 if model_result_name not in derived_dict:
                     raise ValueError(
                         f"Mapped derived result '{model_result_name}' not found."

--- a/ionics_fits/models/containers.py
+++ b/ionics_fits/models/containers.py
@@ -385,7 +385,7 @@ class RepeatedModel(Model):
         dim = self.model.get_num_y_channels()
 
         common_heuristics = {
-            param: [0.0] * self.num_repetitions for param in self.common_params
+            param: np.zeros(self.num_repetitions + 1) for param in self.common_params
         }
 
         for idx in range(self.num_repetitions):
@@ -411,7 +411,7 @@ class RepeatedModel(Model):
         # Combine the heuristics for the repetitions to find the best set of common
         # parameter values
         for param in self.common_params:
-            common_heuristics[param].append(np.mean(common_heuristics[param]))
+            common_heuristics[param][-1] = np.mean(common_heuristics[param][:-1])
 
         param_estimates = {
             param_name: self.parameters[param_name].get_initial_value()

--- a/ionics_fits/models/gaussian.py
+++ b/ionics_fits/models/gaussian.py
@@ -64,17 +64,17 @@ class Gaussian(Model):
         #   F[A * exp(-(x/w)^2)](k) = A * sqrt(pi) * w * exp(-(pi*k*w)^2)
         #
         # Half-width at 1/e when k = 1/(pi*w)
-        omega, spectrum = get_spectrum(x, y, trim_dc=True)
+        omega, spectrum = get_spectrum(x, y, trim_dc=True, density_units=False)
         abs_spectrum = np.abs(spectrum)
 
         k = omega / (2 * np.pi)
 
-        peak = np.max(abs_spectrum)
-        W = peak / np.exp(1)
-        width = 1 / (np.pi * k[np.argmin(np.abs(abs_spectrum - W))])
+        peak = abs_spectrum[0]
+        W = peak * np.exp(-1)
+        half_width = k[np.argmin(np.abs(abs_spectrum - W))]
 
-        sigma = width / 2
-        a = peak * np.pi * np.sqrt(2)
+        sigma = 1 / (np.sqrt(2) * np.pi * half_width)
+        a = peak
 
         self.parameters["y0"].heuristic = np.mean([y[0], y[-1]])
         y0 = self.parameters["y0"].get_initial_value()

--- a/ionics_fits/models/gaussian.py
+++ b/ionics_fits/models/gaussian.py
@@ -70,8 +70,7 @@ class Gaussian(Model):
 
         peak = abs_spectrum[0]
         W = peak * np.exp(-1)
-        # We loose a sample to trim_dc
-        idx_1_e = np.argmin(np.abs(abs_spectrum - W)) + 1
+        idx_1_e = np.argmin(np.abs(abs_spectrum - W))
 
         # We usually don't have great spectral resolution around the peak so interpolate
         if k[idx_1_e] > W:

--- a/ionics_fits/models/gaussian.py
+++ b/ionics_fits/models/gaussian.py
@@ -66,12 +66,30 @@ class Gaussian(Model):
         # Half-width at 1/e when k = 1/(pi*w)
         omega, spectrum = get_spectrum(x, y, trim_dc=True, density_units=False)
         abs_spectrum = np.abs(spectrum)
-
         k = omega / (2 * np.pi)
 
         peak = abs_spectrum[0]
         W = peak * np.exp(-1)
-        half_width = k[np.argmin(np.abs(abs_spectrum - W))]
+        # We loose a sample to trim_dc
+        idx_1_e = np.argmin(np.abs(abs_spectrum - W)) + 1
+
+        # We usually don't have great spectral resolution around the peak so interpolate
+        if k[idx_1_e] > W:
+            upper_idx = idx_1_e
+            lower_idx = idx_1_e + 1
+        else:
+            upper_idx = idx_1_e - 1
+            lower_idx = idx_1_e
+
+        df_dk = (abs_spectrum[lower_idx] - abs_spectrum[upper_idx]) / (k[1] - k[0])
+
+        # if we don't have enough data to figure this out, set the half-width to one
+        # sample wide
+        if df_dk == 0:
+            half_width = k[1] - k[0]
+        else:
+            df = abs_spectrum[idx_1_e] - W
+            half_width = k[idx_1_e] - df / df_dk
 
         sigma = 1 / (np.sqrt(2) * np.pi * half_width)
         a = peak

--- a/ionics_fits/models/heuristics.py
+++ b/ionics_fits/models/heuristics.py
@@ -239,7 +239,7 @@ def get_spectrum(
     dx = x.ptp() / x.size
     n = x.size
     omega = np.fft.fftfreq(n, dx) * (2 * np.pi)
-    y_f = np.fft.fft(y, norm="ortho") / np.sqrt(n)
+    y_f = np.fft.fft(y) * (x.ptp() / n)
 
     y_f = y_f[: int(n / 2)]
     omega = omega[: int(n / 2)]

--- a/ionics_fits/models/lorentzian.py
+++ b/ionics_fits/models/lorentzian.py
@@ -63,8 +63,7 @@ class Lorentzian(Model):
         peak = abs_spectrum[0]
         W = peak * np.exp(-1)
 
-        # We loose a sample to trim_dc
-        idx_1_e = np.argmin(np.abs(abs_spectrum - W)) + 1
+        idx_1_e = np.argmin(np.abs(abs_spectrum - W))
 
         # We usually don't have great spectral resolution around the peak so interpolate
         if k[idx_1_e] > W:

--- a/ionics_fits/models/lorentzian.py
+++ b/ionics_fits/models/lorentzian.py
@@ -2,9 +2,8 @@ from typing import Tuple, TYPE_CHECKING
 import numpy as np
 
 from . import heuristics
-from .exponential import Exponential
 from .heuristics import get_spectrum
-from .. import common, Model, ModelParameter, NormalFitter
+from .. import common, Model, ModelParameter
 from ..utils import Array
 
 
@@ -54,26 +53,49 @@ class Lorentzian(Model):
         # Ensure that y is a 1D array
         y = np.squeeze(y)
 
-        omega, spectrum = get_spectrum(x, y, trim_dc=True)
+        # Fourier transform:
+        #  f(y) = a * fwhmh^2 / ((x - x0)^2 + fwhmh^2) + y0
+        #  f(k) = a * fwhmh * pi * exp(-2*pi*i*k*x0) * exp(-2*pi*fwhmh*|k|)
+        omega, spectrum = get_spectrum(x, y, trim_dc=True, density_units=False)
         abs_spectrum = np.abs(spectrum)
+        k = omega / (2 * np.pi)
 
-        model = Exponential()
-        model.parameters["y0"].heuristic = np.max(abs_spectrum)
-        model.parameters["y_inf"].heuristic = 0.0
-        fit = NormalFitter(omega, abs_spectrum, model)
+        peak = abs_spectrum[0]
+        W = peak * np.exp(-1)
+
+        # We loose a sample to trim_dc
+        idx_1_e = np.argmin(np.abs(abs_spectrum - W)) + 1
+
+        # We usually don't have great spectral resolution around the peak so interpolate
+        if k[idx_1_e] > W:
+            upper_idx = idx_1_e
+            lower_idx = idx_1_e + 1
+        else:
+            upper_idx = idx_1_e - 1
+            lower_idx = idx_1_e
+
+        # if we don't have enough data to figure this out, set the half-width to one
+        # sample wide
+        df_dk = (abs_spectrum[lower_idx] - abs_spectrum[upper_idx]) / (k[1] - k[0])
+        if df_dk == 0:
+            tau = k[1] - k[0]
+        else:
+            df = abs_spectrum[idx_1_e] - W
+            tau = k[idx_1_e] - df / df_dk
+
+        fwhmh = 1 / (2 * np.pi * tau)
+        a = peak / (np.pi * fwhmh)
 
         self.parameters["y0"].heuristic = np.mean([y[0], y[-1]])
         y0 = self.parameters["y0"].get_initial_value()
-
         peak_idx = np.argmax(np.abs(y - y0))
         y_peak = y[peak_idx]
         sgn = 1 if y_peak > y0 else -1
 
-        self.parameters["fwhmh"].heuristic = 1 / fit.values["tau"]
-        fwhmh = self.parameters["fwhmh"].get_initial_value()
-        self.parameters["a"].heuristic = fit.values["y0"] * sgn * 2 / fwhmh
+        self.parameters["a"].heuristic = a * sgn
+        self.parameters["fwhmh"].heuristic = fwhmh
 
-        cut_off = 2 * fit.values["tau"]
+        cut_off = 2 * tau
 
         x0 = heuristics.find_x_offset_sym_peak(
             model=self,

--- a/ionics_fits/models/polynomial.py
+++ b/ionics_fits/models/polynomial.py
@@ -335,9 +335,9 @@ class Parabola(MappedModel):
         """
         super().estimate_parameters(x, y)
 
-        a_0 = self.wrapped_model.parameters["a_0"].get_initial_value()
-        a_1 = self.wrapped_model.parameters["a_1"].heuristic
-        a_2 = self.wrapped_model.parameters["a_2"].get_initial_value()
+        a_0 = self.model.parameters["a_0"].get_initial_value()
+        a_1 = self.model.parameters["a_1"].heuristic
+        a_2 = self.model.parameters["a_2"].get_initial_value()
 
         x0 = -a_1 / (2 * a_2)
         self.parameters["x0"].heuristic = x0

--- a/ionics_fits/models/sinc.py
+++ b/ionics_fits/models/sinc.py
@@ -56,7 +56,9 @@ class Sinc(Model):
         self.parameters["y0"].heuristic = np.mean([y[0], y[-1]])
         y0 = self.parameters["y0"].get_initial_value()
 
-        omega, spectrum = heuristics.get_spectrum(x, y, trim_dc=True, density_units=False)
+        omega, spectrum = heuristics.get_spectrum(
+            x, y, trim_dc=True, density_units=False
+        )
         abs_spectrum = np.abs(spectrum)
 
         # Fourier transform of a sinc is a rectangle
@@ -142,7 +144,7 @@ class Sinc2(Model):
 
         fit = NormalFitter(omega, abs_spectrum, model=tri)
 
-        intercept = fit.values["y0"] / - fit.values["k"]
+        intercept = fit.values["y0"] / -fit.values["k"]
         sgn = 1 if y[np.argmax(np.abs(y - y0))] > y0 else -1
 
         self.parameters["w"].heuristic = w = intercept / 2

--- a/ionics_fits/models/sinc.py
+++ b/ionics_fits/models/sinc.py
@@ -56,7 +56,7 @@ class Sinc(Model):
         self.parameters["y0"].heuristic = np.mean([y[0], y[-1]])
         y0 = self.parameters["y0"].get_initial_value()
 
-        omega, spectrum = heuristics.get_spectrum(x, y, trim_dc=True)
+        omega, spectrum = heuristics.get_spectrum(x, y, trim_dc=True, density_units=False)
         abs_spectrum = np.abs(spectrum)
 
         # Fourier transform of a sinc is a rectangle
@@ -68,10 +68,10 @@ class Sinc(Model):
         fit = NormalFitter(omega, abs_spectrum, model=rect)
 
         self.parameters["w"].heuristic = fit.values["x_r"]
-        w = self.parameters["w"].get_initial_value()
+        w = self.parameters["w"].get_initial_value() + abs_spectrum[1]
 
         sgn = 1 if y[np.argmax(np.abs(y - y0))] > y0 else -1
-        self.parameters["a"].heuristic = 2 * w * fit.values["a"] * sgn
+        self.parameters["a"].heuristic = (w / np.pi) * fit.values["a"] * sgn
 
         x0 = heuristics.find_x_offset_sym_peak(
             model=self,

--- a/ionics_fits/models/sinc.py
+++ b/ionics_fits/models/sinc.py
@@ -142,11 +142,11 @@ class Sinc2(Model):
 
         fit = NormalFitter(omega, abs_spectrum, model=tri)
 
-        intercept = fit.values["y0"] / -fit.values["k"]
+        intercept = fit.values["y0"] / - fit.values["k"]
         sgn = 1 if y[np.argmax(np.abs(y - y0))] > y0 else -1
 
-        self.parameters["w"].heuristic = 0.5 * intercept
-        self.parameters["a"].heuristic = fit.values["y0"] * sgn * intercept
+        self.parameters["w"].heuristic = w = intercept / 2
+        self.parameters["a"].heuristic = fit.values["y0"] * w * sgn
 
         x0 = heuristics.find_x_offset_sym_peak(
             model=self,

--- a/ionics_fits/models/sinusoid.py
+++ b/ionics_fits/models/sinusoid.py
@@ -89,7 +89,7 @@ class Sinusoid(Model):
         spectrum = np.abs(spectrum)
         peak = np.argmax(spectrum)
 
-        self.parameters["a"].heuristic = spectrum[peak] * 2
+        self.parameters["a"].heuristic = spectrum[peak]
         self.parameters["omega"].heuristic = omega[peak]
 
         phi, _ = heuristics.param_min_sqrs(

--- a/ionics_fits/multi_x/__init__.py
+++ b/ionics_fits/multi_x/__init__.py
@@ -1,2 +1,2 @@
 from .common import Model2D
-from .models import Cone, Gaussian2D, Parabola2D
+from .models import Cone2D, Gaussian2D, Parabola2D

--- a/ionics_fits/multi_x/common.py
+++ b/ionics_fits/multi_x/common.py
@@ -149,15 +149,15 @@ class Model2D(Model):
 
     def estimate_parameters(
         self,
-        x: TX,
-        y: TY,
+        x: TX2D,
+        y: TY2D,
     ):
         raise NotImplementedError
 
     def calculate_derived_params(
         self,
-        x: TX,
-        y: TY,
+        x: TX2D,
+        y: TY2D,
         fitted_params: Dict[str, float],
         fit_uncertainties: Dict[str, float],
     ) -> Tuple[Dict[str, float], Dict[str, float]]:

--- a/ionics_fits/multi_x/common.py
+++ b/ionics_fits/multi_x/common.py
@@ -34,32 +34,32 @@ TY2D = Union[
 logger = logging.getLogger(__name__)
 
 
-class Model2D:
-    """Base class providing a :class Model:-like interface for models with
-    2-dimensional x-axes.
-
-    2D x-axis data is represented by the tuple `x=(x_axis_0, x_axis_1)`.
-
-    This class provides a means of combining a pair of 1D :class Model:s to create a 2D
-    model. Each 1D model is a function of one x-axis dimension:
-      `model_0 = models[0] = f(x_axis_0)`
-      `model_1 = models[1] = g(x_axis_1)`
+class Model2D(Model):
+    """Combines a pair of :class Model:s, which are each a function of 1 x-axis, to
+    make a new :class Model:, which is a function of 2 x-axes.
 
     All y-axis data is generated from the output of the first model; the output from
     the second model provides the values of certain "result" parameters used by the
     first model. In other words:
-      `y(x_0, x_1) = model_0(x_0 | result_params = model_1(x_1))`
+      ```
+      model_0 = models[0] = f(x_axis_0)
+      model_1 = models[1] = g(x_axis_1)
+      y(x_0, x_1) = model_0(x_0 | result_params = model_1(x_1))
+      ```
 
-    - All parameters from the two models apart from the first model's *result
-      parameters* are parameters of the 2D model.
+      An intrinsic limitation of this approach is that the overall fit function must
+      be separable into functions of the two axes. This means, for example, that
+      fit-functions must be aligned with the x axes.
+
+    Model parameters and results:
+    - All parameters from the two models - apart from the first model's *result
+      parameters* - are parameters of the 2D model.
     - All derived results from the two models are included in the :class Model2D:'s
       derived results.
     - By default, a parameter/derived result named `param` from a model named `model` is
       exposed as a parameter / result of the :class Model2D: named `param_model`. Custom
       naming schemes are possible by passing a `param_renames` dictionary into
       :meth __init__:.
-
-    See also :class Fitter2D:.
     """
 
     def __init__(

--- a/ionics_fits/multi_x/models.py
+++ b/ionics_fits/multi_x/models.py
@@ -40,12 +40,12 @@ class Gaussian2D(Model2D):
         # non-empty model names and Wrap the 2D model rather than wrapping the 1D
         # models
         inner_model = models.containers.MappedModel(
-            wrapped_model=models.Gaussian(),
+            model=models.Gaussian(),
             param_mapping={"a_x": "a", "x0_x": "x0", "sigma_x": "sigma", "z0": "y0"},
             derived_result_mapping={"FWHMH_x": "FWHMH", "w0_x": "w0"},
         )
         outer_model = models.containers.MappedModel(
-            wrapped_model=models.Gaussian(),
+            model=models.Gaussian(),
             param_mapping={
                 "a": "a",
                 "x0_y": "x0",
@@ -83,11 +83,11 @@ class Parabola2D(Model2D):
         # non-empty model names and Wrap the 2D model rather than wrapping the 1D
         # models
         inner_model = models.containers.MappedModel(
-            wrapped_model=models.Parabola(),
+            model=models.Parabola(),
             param_mapping={"x0": "x0", "y0_x": "y0", "k_x": "k"},
         )
         outer_model = models.containers.MappedModel(
-            wrapped_model=models.Parabola(),
+            model=models.Parabola(),
             param_mapping={"y0": "x0", "z0": "y0", "k_y": "k"},
         )
 
@@ -117,14 +117,14 @@ class Cone2D(Model2D):
         # non-empty model names and Wrap the 2D model rather than wrapping the 1D
         # models
         inner_model = models.containers.MappedModel(
-            wrapped_model=models.ConeSlice(),
+            model=models.ConeSlice(),
             param_mapping={"alpha": "alpha", "y0": "z0", "x0_x": "x0", "k_x": "k"},
         )
 
         triangle = models.Triangle()
         triangle.parameters["y0"].fixed_to = 0
         outer_model = models.containers.MappedModel(
-            wrapped_model=triangle,
+            model=triangle,
             param_mapping={"x0_y": "x0", "k_y": "k"},
             fixed_params={
                 param_name: param_data.fixed_to

--- a/ionics_fits/multi_x/models.py
+++ b/ionics_fits/multi_x/models.py
@@ -42,7 +42,7 @@ class Gaussian2D(Model2D):
         inner_model = models.containers.MappedModel(
             model=models.Gaussian(),
             param_mapping={"a_x": "a", "x0_x": "x0", "sigma_x": "sigma", "z0": "y0"},
-            derived_result_mapping={"FWHMH_x": "FWHMH", "w0_x": "w0"},
+            derived_result_mapping={"FWHMH_x": "FWHMH", "w0_x": "w0", None: "peak"},
         )
         outer_model = models.containers.MappedModel(
             model=models.Gaussian(),
@@ -52,7 +52,7 @@ class Gaussian2D(Model2D):
                 "sigma_y": "sigma",
             },
             fixed_params={"y0": 0},
-            derived_result_mapping={"FWHMH_y": "FWHMH", "w0_y": "w0", "peak_y": "peak"},
+            derived_result_mapping={"FWHMH_y": "FWHMH", "w0_y": "w0"},
         )
 
         super().__init__(

--- a/test/common.py
+++ b/test/common.py
@@ -53,7 +53,9 @@ class TestConfig:
     """Configuration settings for a model test.
 
     Attributes (test are only performed if values are not `None`):
+        :param_tol: tolerance to check fitted parameter values against
         :param residual_tol: tolerance to check fit residuals against
+        :param heuristic_tol: tolerance to check heuristic values against
         :param plot_failures: if `True` we plot the dataset/fit results for failed tests
         :param plot_all: if `True` we plot every run, not just failures (used in
             debugging)
@@ -61,6 +63,7 @@ class TestConfig:
 
     param_tol: Optional[float] = 1e-3
     residual_tol: Optional[float] = None
+    heuristic_tol: Optional[float] = None
     plot_failures: bool = True
     plot_all: bool = False
 
@@ -139,6 +142,22 @@ def check_single_param_set(
             "Error in parameter values is too large:\n"
             f"test parameter set was: {params_str}\n"
             f"fitted parameters were: {fitted_params_str}\n"
+            f"estimated parameters were: {initial_params_str}\n"
+            f"free parameters were: {fit.free_parameters}"
+        )
+
+    if config.heuristic_tol is not None and not params_close(
+        test_params, fit.initial_values, config.heuristic_tol
+    ):
+        if config.plot_failures:
+            _plot(
+                fit,
+                y,
+            )
+
+        raise ValueError(
+            "Error in heuristics is too large:\n"
+            f"test parameter set was: {params_str}\n"
             f"estimated parameters were: {initial_params_str}\n"
             f"free parameters were: {fit.free_parameters}"
         )

--- a/test/test_gaussian.py
+++ b/test/test_gaussian.py
@@ -18,7 +18,7 @@ def test_gaussian(plot_failures):
         x,
         model,
         params,
-        common.TestConfig(plot_failures=plot_failures),
+        common.TestConfig(plot_failures=plot_failures, heuristic_tol=0.2),
     )
 
 

--- a/test/test_lorentzian.py
+++ b/test/test_lorentzian.py
@@ -11,14 +11,14 @@ def test_lorentzian(plot_failures):
         "x0": [-1, 0, 0.25, 2],
         "y0": [-1, 0, 1],
         "a": [-5, 5],
-        "fwhmh": [0.1, 0.25, 1],
+        "fwhmh": [0.1, 0.25, 0.5],
     }
     model = fits.models.Lorentzian()
     common.check_multiple_param_sets(
         x,
         model,
         params,
-        common.TestConfig(plot_failures=plot_failures),
+        common.TestConfig(plot_failures=plot_failures, heuristic_tol=0.2),
     )
 
 

--- a/test/test_lorentzian.py
+++ b/test/test_lorentzian.py
@@ -18,7 +18,25 @@ def test_lorentzian(plot_failures):
         x,
         model,
         params,
-        common.TestConfig(plot_failures=plot_failures, heuristic_tol=0.2),
+        common.TestConfig(plot_failures=plot_failures, heuristic_tol=0.7),
+    )
+
+
+def test_lorentzian_heuristic(plot_failures):
+    """Test lorentzian.Lorentzian heuristic is accurate in an easy situation"""
+    x = np.linspace(-4, 4, 1000)
+    params = {
+        "x0": 0.25,
+        "y0": 1,
+        "a": -5,
+        "fwhmh": 0.25,
+    }
+    model = fits.models.Lorentzian()
+    common.check_multiple_param_sets(
+        x,
+        model,
+        params,
+        common.TestConfig(plot_failures=plot_failures, heuristic_tol=0.05),
     )
 
 

--- a/test/test_lorentzian.py
+++ b/test/test_lorentzian.py
@@ -32,7 +32,7 @@ def test_lorentzian_heuristic(plot_failures):
         "fwhmh": 0.25,
     }
     model = fits.models.Lorentzian()
-    common.check_multiple_param_sets(
+    common.check_single_param_set(
         x,
         model,
         params,

--- a/test/test_multi_x.py
+++ b/test/test_multi_x.py
@@ -157,10 +157,10 @@ def test_gaussian_2d(plot_failures):
     assert set(fit.initial_values.keys()) == set(params.keys())
     assert set(fit.free_parameters) == set(params.keys())
     assert set(fit.derived_values.keys()) == set(
-        ["FWHMH_x", "w0_x", "FWHMH_y", "peak_y", "w0_y"]
+        ["FWHMH_x", "w0_x", "FWHMH_y", "peak", "w0_y"]
     )
     assert set(fit.derived_uncertainties.keys()) == set(
-        ["FWHMH_x", "w0_x", "FWHMH_y", "peak_y", "w0_y"]
+        ["FWHMH_x", "w0_x", "FWHMH_y", "peak", "w0_y"]
     )
 
     _, y_fit = fit.evaluate()

--- a/test/test_multi_x.py
+++ b/test/test_multi_x.py
@@ -182,7 +182,7 @@ def test_cone_2d(plot_failures):
     fit = fits.multi_x.common.Fitter2D(
         x=(x_ax_0, x_ax_1),
         y=y.T,
-        model=fits.multi_x.models.Cone(),
+        model=fits.multi_x.models.Cone2D(),
     )
 
     check_param_values(x_mesh_0, x_mesh_1, params, fit, cone, plot_failures)

--- a/test/test_sinc.py
+++ b/test/test_sinc.py
@@ -70,7 +70,7 @@ def test_sinc2_heuristic(plot_failures: bool):
         "w": 3,
     }
     model = fits.models.Sinc2()
-    common.check_multiple_param_sets(
+    common.check_single_param_set(
         x,
         model,
         params,

--- a/test/test_sinc.py
+++ b/test/test_sinc.py
@@ -8,7 +8,7 @@ from . import common
 
 def test_sinc(plot_failures: bool):
     """Test for sinc.Sinc"""
-    x = np.linspace(-20, 10, 200)
+    x = np.linspace(-20, 20, 200)
     params = {
         "x0": [-13, -1, 0, 1, 5],
         "y0": [-1, 0, 10],
@@ -20,9 +20,25 @@ def test_sinc(plot_failures: bool):
         x,
         model,
         params,
-        common.TestConfig(plot_failures=plot_failures),
+        common.TestConfig(plot_failures=plot_failures, heuristic_tol=0.25),
     )
 
+def test_sinc_heuristic(plot_failures: bool):
+    """Test sinc.Sinc heuristic gives an accurate estimate in an easy case"""
+    x = np.linspace(-20, 20, 200)
+    params = {
+        "x0": 5,
+        "y0": 2,
+        "a": -4,
+        "w": 3,
+    }
+    model = fits.models.Sinc()
+    common.check_multiple_param_sets(
+        x,
+        model,
+        params,
+        common.TestConfig(plot_failures=plot_failures, heuristic_tol=0.05),
+    )
 
 def test_sinc2(plot_failures: bool):
     """Test for sinc.Sinc2"""

--- a/test/test_sinc.py
+++ b/test/test_sinc.py
@@ -23,6 +23,7 @@ def test_sinc(plot_failures: bool):
         common.TestConfig(plot_failures=plot_failures, heuristic_tol=0.25),
     )
 
+
 def test_sinc_heuristic(plot_failures: bool):
     """Test sinc.Sinc heuristic gives an accurate estimate in an easy case"""
     x = np.linspace(-20, 20, 200)
@@ -39,6 +40,7 @@ def test_sinc_heuristic(plot_failures: bool):
         params,
         common.TestConfig(plot_failures=plot_failures, heuristic_tol=0.05),
     )
+
 
 def test_sinc2(plot_failures: bool):
     """Test for sinc.Sinc2"""
@@ -57,6 +59,7 @@ def test_sinc2(plot_failures: bool):
         common.TestConfig(plot_failures=plot_failures, heuristic_tol=0.25),
     )
 
+
 def test_sinc2_heuristic(plot_failures: bool):
     """Test sinc.Sinc2 heuristic gives an accurate estimate in an easy case"""
     x = np.linspace(-20, 20, 200)
@@ -73,6 +76,7 @@ def test_sinc2_heuristic(plot_failures: bool):
         params,
         common.TestConfig(plot_failures=plot_failures, heuristic_tol=0.02),
     )
+
 
 def sinc_param_generator(
     fuzzed_params: Dict[str, Tuple[float, float]]

--- a/test/test_sinc.py
+++ b/test/test_sinc.py
@@ -42,7 +42,7 @@ def test_sinc_heuristic(plot_failures: bool):
 
 def test_sinc2(plot_failures: bool):
     """Test for sinc.Sinc2"""
-    x = np.linspace(-10, 20, 400)
+    x = np.linspace(-20, 20, 400)
     params = {
         "x0": [-8, -1, 0, 1, 5, 15],
         "y0": [-1, 0, 10],
@@ -54,9 +54,25 @@ def test_sinc2(plot_failures: bool):
         x,
         model,
         params,
-        common.TestConfig(plot_failures=plot_failures),
+        common.TestConfig(plot_failures=plot_failures, heuristic_tol=0.25),
     )
 
+def test_sinc2_heuristic(plot_failures: bool):
+    """Test sinc.Sinc2 heuristic gives an accurate estimate in an easy case"""
+    x = np.linspace(-20, 20, 200)
+    params = {
+        "x0": 5,
+        "y0": 2,
+        "a": -4,
+        "w": 3,
+    }
+    model = fits.models.Sinc2()
+    common.check_multiple_param_sets(
+        x,
+        model,
+        params,
+        common.TestConfig(plot_failures=plot_failures, heuristic_tol=0.02),
+    )
 
 def sinc_param_generator(
     fuzzed_params: Dict[str, Tuple[float, float]]

--- a/test/test_sinc.py
+++ b/test/test_sinc.py
@@ -34,7 +34,7 @@ def test_sinc_heuristic(plot_failures: bool):
         "w": 3,
     }
     model = fits.models.Sinc()
-    common.check_multiple_param_sets(
+    common.check_single_param_set(
         x,
         model,
         params,

--- a/test/test_sinusoid.py
+++ b/test/test_sinusoid.py
@@ -9,7 +9,7 @@ def test_sinusoid(plot_failures: bool):
     x = np.linspace(-10, 10, 1000)
     params = {
         "a": 2,
-        "omega": [1 / (2 * np.pi), 5 / (2 * np.pi), 10 / (2 * np.pi)],
+        "omega": [3 / (2 * np.pi), 5 / (2 * np.pi), 10 / (2 * np.pi)],
         "phi": 0.5,
         "y0": 1,
         "x0": 0,
@@ -17,7 +17,30 @@ def test_sinusoid(plot_failures: bool):
     }
     model = fits.models.Sinusoid()
     common.check_multiple_param_sets(
-        x, model, params, common.TestConfig(plot_failures=plot_failures)
+        x,
+        model,
+        params,
+        common.TestConfig(plot_failures=plot_failures, heuristic_tol=0.45),
+    )
+
+
+def test_sinusoid_heuristic(plot_failures: bool):
+    """Check that the sinusoid heuristic gives an accurate estimate in an easy case"""
+    x = np.linspace(-10, 10, 1000)
+    params = {
+        "a": 2,
+        "omega": 10 / (2 * np.pi),
+        "phi": 0.5,
+        "y0": 1,
+        "x0": 0,
+        "tau": np.inf,
+    }
+    model = fits.models.Sinusoid()
+    common.check_single_param_set(
+        x,
+        model,
+        params,
+        common.TestConfig(plot_failures=plot_failures, heuristic_tol=0.02),
     )
 
 


### PR DESCRIPTION
In preparation for full support for models with multi-dimensional x-axis data.

Changes:
- `Model2D` is now a subclass of `Model`
- `WrappedModel` now calculates derived parameters
- `WrappedModel` allows remapping names of derived parameters
- `Model2D` no longer provides functionality to rename parameters / results - use a `WrappedModel` for that instead
- Small tweaks to the parameter / result naming in the 2D models for improved consistency 
- Fix normalization of FFT in `get_spectrum`
- Fix FFT-based heuristics in `gaussian`, `lorentzian`, `sinc` and `sinc2` models
- `Model` now has `get_num_x_axes` and `clear_heuristics` methods
- Tests can now check accuracy of heuristics as well
- Improve test coverage to start checking heuristics in some models
- `WrappedModel` rename `wrapped_model` parameter to `model` for consistency with other containers
- rename `Cone` to `Cone2D`