### PR TITLE
MLE numerics

### DIFF
--- a/ionics_fits/MLE.py
+++ b/ionics_fits/MLE.py
@@ -77,7 +77,7 @@ class MLEFitter(Fitter):
         x: TX,
         y: TY,
         free_func: Callable[..., TY],
-        jacobian_func: Callable[List[int], TJACOBIAN],
+        jacobian_func: Callable[[List[int]], TJACOBIAN],
     ) -> (float, Array[("num_free_params",), np.float64]):
         """Cost function used during fitting.
 
@@ -103,7 +103,7 @@ class MLEFitter(Fitter):
 
     def hessian(
         self, x: TX, y: TY, param_values: Dict[str, float], free_params: List[int]
-    ) -> (float, Array[("num_free_params", "num_free_params"), np.float64]):
+    ) -> Array[("num_free_params", "num_free_params"), np.float64]:
         """Hessian of the cost function, used to calculate the parameter covariance
         matrix.
 

--- a/ionics_fits/binomial.py
+++ b/ionics_fits/binomial.py
@@ -1,12 +1,11 @@
 import logging
-from typing import Callable, Dict, Optional, TYPE_CHECKING
+from typing import Callable, Dict, List, Optional, TYPE_CHECKING
 
 import numpy as np
-from scipy import stats
 from statsmodels.stats import proportion
 
 
-from .common import Model, TX, TY
+from .common import Model, TJACOBIAN, TX, TY
 from .MLE import MLEFitter
 from .utils import Array
 
@@ -58,24 +57,103 @@ class BinomialFitter(MLEFitter):
             x=x, y=y, model=model, step_size=step_size, minimizer_args=minimizer_args
         )
 
-    def log_likelihood(
+    def cost_func(
         self,
         free_param_values: Array[("num_free_params",), np.float64],
         x: TX,
         y: TY,
         free_func: Callable[..., TY],
-    ) -> float:
+        jacobian_func: Callable[[List[int]], TJACOBIAN],
+    ) -> (float, Array[("num_free_params",), np.float64]):
         p = free_func(x, *free_param_values.tolist())
+
+        # avoid divide by zero issues when p is exactly 0 or 1
+        eps = 1e-12
+        p[p == 0] = eps
+        p[p == 1] = 1 - eps
 
         if np.any(p < 0) or np.any(p > 1):
             raise RuntimeError("Model values must lie between 0 and 1")
 
         n = self.num_trials
-        k = np.rint(y * n, out=np.zeros_like(y, dtype=int), casting="unsafe")
-        logP = stats.binom.logpmf(k=k, n=n, p=p)
-        C = -np.sum(logP)
+        k = y * n
 
-        return C
+        # The negative Log-Likelihood for a Binomial distribution is:
+        # L = -sum(log(BinomPMF(k, n, p)))
+        # L = -sum(log(Choose(n, k)) + k*log(p) + (n-k)*log(q))
+        # L = -sum(log(Choose(n, k))) - sum(k*log(p) + (n-k)*log(q)))
+        #
+        # where: BinomPMF = Choose(n, k) * p^k * q^(n - k)
+        #
+        # Since the combinatorial part is just a constant offset we do not need to
+        # include it in our cost function. We can thus simplify to:
+        #
+        # C = -sum(k*log(p) + (n-k)*log(q)
+        C = -np.sum(k * np.log(p) + (n - k) * np.log(1 - p))
+
+        # Calculate Jacobian:
+        #
+        # C = -sum(k*log(p) + (n-k)*log(1 - p)
+        # dC/d(param) = -sum(k / p * dp/d(param) - (n-k) / (1 - p) * dp/d(param))
+        # dC/d(param) = sum(dp/d(param) * ((n-k) / (1 - p) - k / p))
+
+        model_jac = jacobian_func(free_param_values)
+        jac = np.sum(model_jac * ((n - k) / (1 - p) - k / p), axis=(1, 2))
+
+        return (C, jac)
+
+    def hessian(
+        self, x: TX, y: TY, param_values: Dict[str, float], free_params: List[int]
+    ) -> Array[("num_free_params", "num_free_params"), np.float64]:
+        # dC/d(param) = sum(dp/d(param) * ((n-k) / (1 - p) - k / p))
+        #
+        # d2C/d(param_i)d(param_j) = sum(
+        #  d2p/d(param_i)d(param_j) * ((n-k) / (1 - p) - k / p)
+        #  + dp/d(param_i) * dp/d(param_j) * (k/p^2 + (n-k)/(1-p)^2)
+        # )
+        #
+        # d2C/d(param_i)d(param_j) = sum(
+        #  A * d2p/d(param_i)d(param_j)
+        #  + B * dp/d(param_i) * dp/d(param_j)
+        # )
+        #
+        # where:
+        #  A = ((n-k) / (1 - p) - k / p)
+        #  B = (k/p^2 + (n-k) / (1-p)^2)
+
+        x = np.atleast_2d(x)
+        p = self.model.func(x, param_values)
+        n = self.num_trials
+        k = y * n
+
+        # avoid divide by zero issues when p is exactly 0 or 1
+        eps = 1e-12
+        p[p == 0] = eps
+        p[p == 1] = 1 - eps
+
+        A = (n - k) / (1 - p) - k / p
+        B = k / (p**2) + (n - k) / ((1 - p) ** 2)
+
+        model_jacobian = self.model.jacobian(
+            x=x, param_values=param_values, included_params=free_params
+        )
+        model_hessian = self.model.hessian(
+            x=x, param_values=param_values, included_params=free_params
+        )
+
+        num_free_params = len(free_params)
+        hessian = np.zeros((num_free_params, num_free_params) + x.shape)
+
+        for i_idx in range(num_free_params):
+            for j_idx in range(num_free_params):
+                hessian[i_idx, j_idx, :, :] = (
+                    A * model_hessian[i_idx, j_idx, :, :]
+                    + B * model_jacobian[i_idx, :, :] * model_jacobian[j_idx, :, :]
+                )
+
+        hessian = np.sum(hessian, axis=(2, 3))
+
+        return hessian
 
     def calc_sigma(self) -> TY:
         """Return an array of standard error values for each y-axis data point."""

--- a/ionics_fits/common.py
+++ b/ionics_fits/common.py
@@ -550,10 +550,10 @@ class Model:
             )
 
             jac_lower = self.jacobian(
-                x=x, param_values=lower_values, diff_params=included_params
+                x=x, param_values=lower_values, included_params=included_params
             )
             jac_upper = self.jacobian(
-                x=x, param_values=upper_values, diff_params=included_params
+                x=x, param_values=upper_values, included_params=included_params
             )
 
         for param_idx, param_name in enumerate(included_params):

--- a/ionics_fits/common.py
+++ b/ionics_fits/common.py
@@ -45,6 +45,8 @@ TY = Union[
     Array[("num_samples"), np.float64],
     Array[("num_y_axes", "num_samples"), np.float64],
 ]
+TJACOBIAN = Array[("num_params", "num_y_axes", "num_samples"), np.float64]
+THESSIAN = Array[("num_params", "num_params", "num_y_axes", "num_samples"), np.float64]
 
 
 @dataclasses.dataclass
@@ -468,7 +470,7 @@ class Model:
         x: TX,
         param_values: Dict[str, float],
         included_params: Optional[List[str]] = None,
-    ) -> Array[("num_params", "num_x_axes", "num_samples"), np.float64]:
+    ) -> TJACOBIAN:
         r"""Calculates the Jacobian of the model function.
 
         The Jacobian is represented the array::
@@ -495,7 +497,7 @@ class Model:
         if included_params is None:
             included_params = self.parameters.keys()
 
-        jac = np.zeros((len(included_params),) + x.shape)
+        jac = np.zeros((len(included_params), self.get_num_y_axes(), x.shape[1]))
 
         for param_idx, param_name in enumerate(included_params):
             jac[param_idx, :, :] = num_diff(
@@ -512,7 +514,7 @@ class Model:
         x: TX,
         param_values: Dict[str, float],
         included_params: Optional[List[str]] = None,
-    ) -> Array[("num_params", "num_params", "num_x_axes", "num_samples"), np.float64]:
+    ) -> THESSIAN:
         r"""Calculates the Hessian of the model function.
 
         The Hessian is represented the matrix::
@@ -540,7 +542,7 @@ class Model:
             included_params = self.parameters.keys()
 
         num_params = len(included_params)
-        hessian = np.zeros((num_params, num_params) + x.shape)
+        hessian = np.zeros((num_params, num_params, self.get_num_y_axes(), x.shape[1]))
 
         for param_idx, param_name in enumerate(included_params):
             lower_values, upper_values, step = step_param(

--- a/ionics_fits/models/sinusoid.py
+++ b/ionics_fits/models/sinusoid.py
@@ -141,6 +141,43 @@ class Sinusoid(Model):
 
         return derived_params, derived_uncertainties
 
+    def jacobian(
+        self,
+        x: TX,
+        param_values: Dict[str, float],
+        included_params=None,
+    ):
+        x = np.atleast_2d(x)
+        jac = np.zeros((len(included_params), self.get_num_y_axes(), x.shape[1]))
+
+        a = param_values["a"]
+        omega = param_values["omega"]
+        phi = param_values["phi"]
+        y0 = param_values["y0"]
+        x0 = param_values["x0"]
+        tau = param_values["tau"]
+
+        Gamma = np.exp(-x / tau)
+        alpha = np.sin(omega * (x - x0) + phi)
+        beta = np.cos(omega * (x - x0) + phi)
+
+        # y = Gamma * a * np.sin(omega * (x - x0) + phi) + y0
+
+        if "a" in included_params:
+            jac[included_params.index("a"), :, :] = Gamma * alpha
+        if "omega" in included_params:
+            jac[included_params.index("omega"), :, :] = Gamma * a * beta * (x - x0)
+        if "phi" in included_params:
+            jac[included_params.index("phi"), :, :] = Gamma * a * beta
+        if "y0" in included_params:
+            jac[included_params.index("y0"), :, :] = 1
+        if "x0" in included_params:
+            jac[included_params.index("x0"), :, :] = Gamma * a * beta * omega
+        if "tau" in included_params:
+            jac[included_params.index("tau"), :, :] = -Gamma * a * alpha / tau
+
+        return jac
+
 
 class SineMinMax(ReparametrizedModel):
     """Sinusoid parametrised by minimum / maximum values instead of offset / amplitude::
@@ -188,6 +225,41 @@ class SineMinMax(ReparametrizedModel):
             "max": (model_param_values["y0"] + model_param_values["a"]),
             "min": (model_param_values["y0"] - model_param_values["a"]),
         }
+
+    def jacobian(
+        self,
+        x: TX,
+        param_values: Dict[str, float],
+        included_params=None,
+    ):
+        x = np.atleast_2d(x)
+        jac = np.zeros((len(included_params), self.get_num_y_axes(), x.shape[1]))
+
+        a = 0.5 * (param_values["max"] - param_values["min"])
+        y0 = 0.5 * (param_values["max"] + param_values["min"])
+        omega = param_values["omega"]
+        phi = param_values["phi"]
+        x0 = param_values["x0"]
+        tau = param_values["tau"]
+
+        Gamma = np.exp(-x / tau)
+        alpha = np.sin(omega * (x - x0) + phi)
+        beta = np.cos(omega * (x - x0) + phi)
+
+        if "max" in included_params:
+            jac[included_params.index("max"), :, :] = 0.5 * (1 + Gamma * alpha)
+        if "min" in included_params:
+            jac[included_params.index("min"), :, :] = 0.5 * (1 - Gamma * alpha)
+        if "omega" in included_params:
+            jac[included_params.index("omega"), :, :] = Gamma * a * beta * (x - x0)
+        if "phi" in included_params:
+            jac[included_params.index("phi"), :, :] = Gamma * a * beta
+        if "x0" in included_params:
+            jac[included_params.index("x0"), :, :] = Gamma * a * beta * omega
+        if "tau" in included_params:
+            jac[included_params.index("tau"), :, :] = -Gamma * a * alpha / tau
+
+        return jac
 
 
 class Sine2(Sinusoid):

--- a/ionics_fits/utils.py
+++ b/ionics_fits/utils.py
@@ -1,8 +1,10 @@
 import numpy as np
-from typing import Callable, List, Union, TYPE_CHECKING
+from typing import Callable, Dict, List, Tuple, Union, TYPE_CHECKING
 
 
 if TYPE_CHECKING:
+    from .common import Model, TX
+
     num_x_axes = float
     num_y_axes = float
 
@@ -154,3 +156,96 @@ def scale_no_rescale(x_scales: TX_SCALE, y_scales: TY_SCALE) -> float:
         )
 
     return 1.0
+
+
+def step_param(
+    model: "Model",
+    stepped_param: str,
+    param_values: Dict[str, float],
+    step_size: float = 1e-4,
+) -> Tuple[Dict[str, float], Dict[str, float], float]:
+    """Generates parameter value dictionaries with one parameter stepped. Used by
+    numerical differentiation routines.
+
+    :param model: :class:`~ionics_fits.common.Model` whose parameters we are varying
+    :param stepped_param: name of the stepped parameter
+    :param param_values: dictionary of parameter values
+    :param step_size: base step size. As a rule of thumb this should not be larger than
+        ``~1e-5``. See section 5.7 of `Numerical Recipes` (third edition) for discussion
+        of numerical differentiation. If the stepped parameter has lower and upper
+        bounds set, we use ``(upper_bound - lower_bound) * step_size`` as the step size,
+        otherwise we use ``step_size`` directly.
+    :returns: tuple of ``(lower_values, upper_values, step)`` where: ``lower_values`` is
+        a modified ``param_values`` dictionary with ``stepped_param`` decreased by half
+        of the step size (clipped to its lower bound); ``upper_values`` is a modified
+        ``param_values`` dictionary with ``stepped_param`` stepped upwards; and,
+        ``step`` is the size of the step taking clipping into account.
+    """
+    param_data = model.parameters[stepped_param]
+    lower_bound = param_data.lower_bound
+    upper_bound = param_data.upper_bound
+    stepped_param_value = param_values[stepped_param]
+
+    if np.isfinite(lower_bound) and np.isfinite(upper_bound):
+        step_size = step_size * (upper_bound - lower_bound)
+    else:
+        step_size = step_size
+
+    param_lower = np.clip(
+        stepped_param_value - 0.5 * step_size,
+        a_min=lower_bound,
+        a_max=upper_bound,
+    )
+    param_upper = np.clip(
+        stepped_param_value + 0.5 * step_size,
+        a_min=lower_bound,
+        a_max=upper_bound,
+    )
+
+    step = param_upper - param_lower
+
+    lower_values = dict(param_values)
+    upper_values = dict(param_values)
+    lower_values[stepped_param] = param_lower
+    upper_values[stepped_param] = param_upper
+
+    return lower_values, upper_values, step
+
+
+def num_diff(
+    model: "Model",
+    diff_param: str,
+    x: "TX",
+    param_values: Dict[str, float],
+    step_size: float = 1e-4,
+) -> float:
+    """Returns the numerical derivative of a model function with respect to one of its
+    parameter.
+
+    This function calculates the derivative::
+
+        d(fun)/d(param)[x, param_values]
+
+    :param model: the model function to differentiate
+    :param diff_param: name of the parameter to differentiate the model function with
+        respect to
+    :param x: x-axis point to evaluate the derivative at
+    :param param_values: dictionary of parameter values to evaluate the derivative at.
+    :param step_size: base step size. As a rule of thumb this should not be larger than
+        ``~1e-5``. See section 5.7 of `Numerical Recipes` (third edition) for discussion
+        of numerical differentiation. If the stepped parameter has lower and upper
+        bounds set, we use ``(upper_bound - lower_bound) * step_size`` as the step size,
+        otherwise we use ``step_size`` directly.
+    :returns: the model function's derivative with respect to the selected parameter
+    """
+    lower_values, upper_values, param_step = step_param(
+        model=model,
+        stepped_param=diff_param,
+        param_values=param_values,
+        step_size=step_size,
+    )
+
+    f_lower = model.func(x, lower_values)
+    f_upper = model.func(x, upper_values)
+
+    return (f_upper - f_lower) / param_step

--- a/ionics_fits/utils.py
+++ b/ionics_fits/utils.py
@@ -214,7 +214,7 @@ def step_param(
 
 def num_diff(
     model: "Model",
-    diff_param: str,
+    differentiated_param: str,
     x: "TX",
     param_values: Dict[str, float],
     step_size: float = 1e-4,
@@ -227,8 +227,8 @@ def num_diff(
         d(fun)/d(param)[x, param_values]
 
     :param model: the model function to differentiate
-    :param diff_param: name of the parameter to differentiate the model function with
-        respect to
+    :param differentiated_param: name of the parameter to differentiate the model
+        function with respect to
     :param x: x-axis point to evaluate the derivative at
     :param param_values: dictionary of parameter values to evaluate the derivative at.
     :param step_size: base step size. As a rule of thumb this should not be larger than
@@ -240,7 +240,7 @@ def num_diff(
     """
     lower_values, upper_values, param_step = step_param(
         model=model,
-        stepped_param=diff_param,
+        stepped_param=differentiated_param,
         param_values=param_values,
         step_size=step_size,
     )

--- a/test/test_binomial.py
+++ b/test/test_binomial.py
@@ -61,11 +61,8 @@ def test_binomial_synthetic(plot_failures):
     model.parameters["min"].upper_bound = 0.5
     model.parameters["max"].lower_bound = 0.5
     model.parameters["max"].upper_bound = 1
-
     model.parameters["omega"].lower_bound = 0
     model.parameters["omega"].upper_bound = 10
-    model.parameters["phi"].lower_bound = 0
-    model.parameters["phi"].upper_bound = 2
     model.parameters["x0"].lower_bound = 0
     model.parameters["x0"].upper_bound = 1
 


### PR DESCRIPTION
This PR changes how we handle numerics around the MLE fitting to make them faster (roughly 5x for the binomial fitter) and more robust / accurate. Since we now calculate a Jacobian, we can use the full array of minimizer options that `scipy` provides, rather than just the ones which don't ask for a Jacobian.

In detail:
- `Model` now provides `jacobian` and `hessian` functions. By default these use numerical (2 point) derivatives, however they can be overridden by `Model` specializations to provide analytic derivatives. So far this has only been done for the sinusoid models
- Refactored the cost function for the `BinomialFitter` to improve speed and accuracy. We no longer use the full binomial pmf, but just the bits that matter for the cost function and we calculate the jacobian ourselves
- 