### PR TITLE
Correcting formula for Lorentzian

### DIFF
--- a/ionics_fits/models/lorentzian.py
+++ b/ionics_fits/models/lorentzian.py
@@ -39,7 +39,7 @@ class Lorentzian(Model):
         :param a: peak value of the function above ``y0``
         :param fwhmh: full width at half maximum height of the function
         """
-        y = a * fwhmh**2 / ((x - x0) ** 2 + fwhmh**2) + y0
+        y = a * (0.5 * fwhmh)**2 / ((x - x0) ** 2 + (0.5 * fwhmh)**2) + y0
         return y
 
     # pytype: enable=invalid-annotation


### PR DESCRIPTION
The FWHM is used instead of the HWHM, see https://en.wikipedia.org/wiki/Cauchy_distribution