### PR TITLE
change model to not include inverting Clifford in SPAM estimate

### DIFF
--- a/ionics_fits/models/benchmarking.py
+++ b/ionics_fits/models/benchmarking.py
@@ -8,9 +8,10 @@ from ..utils import scale_no_rescale
 class Benchmarking(Model):
     """Benchmarking success probability decay model according to::
 
-        y = (y0 - y_inf)*p^x + y_inf
+        y = (y0 - y_inf)*p^(x+1) + y_inf
 
-    where ``x`` is the sequence length (number of Clifford operations).
+    where ``x`` is the sequence length (number of Clifford operations without
+    including the inverting Clifford).
 
     See :meth:`_func` for parameter details.
     """
@@ -59,7 +60,7 @@ class Benchmarking(Model):
         :param y_inf: depolarisation offset (y-axis asymptote) (fixed to ``1/2^n`` by
           default)
         """
-        y = (y0 - y_inf) * p**x + y_inf
+        y = (y0 - y_inf) * p ** (x + 1) + y_inf
         return y
 
     # pytype: enable=invalid-annotation

--- a/test/test_benchmarking.py
+++ b/test/test_benchmarking.py
@@ -6,7 +6,7 @@ from .common import check_multiple_param_sets, fuzz, Config
 
 def test_benchmarking(plot_failures):
     """Test for benchmarking.Benchmarking"""
-    x = np.linspace(0, 1000, 300)
+    x = np.linspace(1, 1000, 300)
     params = {"p": [0.1, 0.3, 0.9], "y0": [0.9, 0.99], "y_inf": 1 / 2**2}
     model = Benchmarking(num_qubits=2)
     check_multiple_param_sets(
@@ -22,7 +22,7 @@ def fuzz_benchmarking(
     stop_at_failure: bool,
     test_config: Config,
 ) -> float:
-    x = np.linspace(0, 1000, 300)
+    x = np.linspace(1, 1000, 300)
     fuzzed_params = {
         "p": (0.1, 0.3),
         "y0": (0.9, 0.99),


### PR DESCRIPTION
A sequence length of N cliffords actually has N+1 Cliffords because of the inverting operation. With the current model, the error from the inverting Clifford is included in the SPAM estimate. This PR changes the model such that the inverting Clifford is taken into account in the sequence length, and the SPAM estimate does not include the error from the inverting Clifford anymore. 